### PR TITLE
chore(deps): bump https://github.com/jenkins-x/jenkins-x-builders from 0.1.560, 0.1.837, 2.0.876-229 to 2.0.1165-501

### DIFF
--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -2,4 +2,5 @@
 
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
-[jenkins-x/jenkins-x-builders](https://github.com/jenkins-x/jenkins-x-builders) |  | [2.0.1165-501]() | 
+[jenkins-x/jenkins-x-builders](https://github.com/jenkins-x/jenkins-x-builders) |  | [2.0.1165-501](https://github.com/jenkins-x/jenkins-x-builders/releases/tag/v2.0.1165-501) | 
+[jenkins-x/jx](https://github.com/jenkins-x/jx) | [github.com/jenkins-x/jenkins-x-builders](https://github.com/jenkins-x/jenkins-x-builders) | [2.0.1165](https://github.com/jenkins-x/jx/releases/tag/v2.0.1165) | 

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -4,4 +4,20 @@ dependencies:
   repo: jenkins-x-builders
   url: https://github.com/jenkins-x/jenkins-x-builders
   version: 2.0.1165-501
-  versionURL: ""
+  versionURL: https://github.com/jenkins-x/jenkins-x-builders/releases/tag/v2.0.1165-501
+- host: github.com
+  owner: jenkins-x
+  repo: jx
+  sources:
+  - path:
+    - host: github.com
+      owner: jenkins-x
+      repo: jenkins-x-builders
+      url: https://github.com/jenkins-x/jenkins-x-builders
+      version: 2.0.1165-501
+      versionURL: https://github.com/jenkins-x/jenkins-x-builders/releases/tag/v2.0.1165-501
+    version: 2.0.1165
+    versionURL: https://github.com/jenkins-x/jx/releases/tag/v2.0.1165
+  url: https://github.com/jenkins-x/jx
+  version: 2.0.1165
+  versionURL: https://github.com/jenkins-x/jx/releases/tag/v2.0.1165

--- a/jxboot-helmfile-resources/values.yaml
+++ b/jxboot-helmfile-resources/values.yaml
@@ -526,7 +526,7 @@ podTemplates:
           requestMemory: "128Mi"
           args: '${computer.jnlpmac} ${computer.name}'
         aws-cdk:
-          image: gcr.io/jenkinsxio/builder-maven-nodejs:2.0.876-229
+          image: gcr.io/jenkinsxio/builder-maven-nodejs:2.0.1165-501
           privileged: true
           requestCpu: "400m"
           requestMemory: "512Mi"
@@ -581,7 +581,7 @@ podTemplates:
           requestMemory: "128Mi"
           args: '${computer.jnlpmac} ${computer.name}'
         Maven:
-          image: gcr.io/jenkinsxio/builder-maven:2.0.876-229
+          image: gcr.io/jenkinsxio/builder-maven:2.0.1165-501
           privileged: true
           requestCpu: "400m"
           requestMemory: "512Mi"
@@ -637,7 +637,7 @@ podTemplates:
           requestMemory: "128Mi"
           args: '${computer.jnlpmac} ${computer.name}'
         Maven:
-          image: gcr.io/jenkinsxio/builder-maven-java11:2.0.876-229
+          image: gcr.io/jenkinsxio/builder-maven-java11:2.0.1165-501
           privileged: true
           requestCpu: "400m"
           requestMemory: "512Mi"
@@ -693,7 +693,7 @@ podTemplates:
           requestMemory: "128Mi"
           args: '${computer.jnlpmac} ${computer.name}'
         Maven:
-          image: gcr.io/jenkinsxio/builder-maven-graalvm:0.1.560
+          image: gcr.io/jenkinsxio/builder-maven-graalvm:2.0.1165-501
           privileged: true
           requestCpu: "400m"
           requestMemory: "2Gi"
@@ -743,7 +743,7 @@ podTemplates:
           requestMemory: "128Mi"
           args: '${computer.jnlpmac} ${computer.name}'
         Gradle:
-          image: gcr.io/jenkinsxio/builder-gradle:2.0.876-229
+          image: gcr.io/jenkinsxio/builder-gradle:2.0.1165-501
           privileged: true
           requestCpu: "400m"
           requestMemory: "512Mi"
@@ -796,7 +796,7 @@ podTemplates:
           requestMemory: "128Mi"
           args: '${computer.jnlpmac} ${computer.name}'
         Scala:
-          image: gcr.io/jenkinsxio/builder-scala:2.0.876-229
+          image: gcr.io/jenkinsxio/builder-scala:2.0.1165-501
           privileged: true
           requestCpu: "400m"
           requestMemory: "512Mi"
@@ -842,7 +842,7 @@ podTemplates:
           requestMemory: "128Mi"
           args: '${computer.jnlpmac} ${computer.name}'
         Go:
-          image: gcr.io/jenkinsxio/builder-go:2.0.876-229
+          image: gcr.io/jenkinsxio/builder-go:2.0.1165-501
           privileged: true
           requestCpu: "400m"
           requestMemory: "600Mi"
@@ -887,7 +887,7 @@ podTemplates:
           requestMemory: "128Mi"
           args: '${computer.jnlpmac} ${computer.name}'
         Terraform:
-          image: gcr.io/jenkinsxio/builder-terraform:2.0.876-229
+          image: gcr.io/jenkinsxio/builder-terraform:2.0.1165-501
           privileged: true
           requestCpu: "400m"
           requestMemory: "600Mi"
@@ -933,7 +933,7 @@ podTemplates:
           requestMemory: "128Mi"
           args: '${computer.jnlpmac} ${computer.name}'
         Rust:
-          image: gcr.io/jenkinsxio/builder-rust:2.0.876-229
+          image: gcr.io/jenkinsxio/builder-rust:2.0.1165-501
           privileged: true
           requestCpu: "400m"
           requestMemory: "512Mi"
@@ -979,7 +979,7 @@ podTemplates:
           requestMemory: "128Mi"
           args: '${computer.jnlpmac} ${computer.name}'
         Newman:
-          image: gcr.io/jenkinsxio/builder-newman:2.0.876-229
+          image: gcr.io/jenkinsxio/builder-newman:2.0.1165-501
           privileged: true
           requestCpu: "400m"
           requestMemory: "512Mi"
@@ -1026,7 +1026,7 @@ podTemplates:
           requestMemory: "128Mi"
           args: '${computer.jnlpmac} ${computer.name}'
         Nodejs:
-          image: gcr.io/jenkinsxio/builder-nodejs8x:2.0.876-229
+          image: gcr.io/jenkinsxio/builder-nodejs8x:2.0.1165-501
           privileged: true
           requestCpu: "400m"
           requestMemory: "512Mi"
@@ -1073,7 +1073,7 @@ podTemplates:
           requestMemory: "128Mi"
           args: '${computer.jnlpmac} ${computer.name}'
         Nodejs:
-          image: gcr.io/jenkinsxio/builder-nodejs10x:2.0.876-229
+          image: gcr.io/jenkinsxio/builder-nodejs10x:2.0.1165-501
           privileged: true
           requestCpu: "400m"
           requestMemory: "512Mi"
@@ -1109,7 +1109,7 @@ podTemplates:
           requestMemory: "128Mi"
           args: '${computer.jnlpmac} ${computer.name}'
         Nodejs:
-          image: gcr.io/jenkinsxio/builder-nodejs12x:2.0.876-229
+          image: gcr.io/jenkinsxio/builder-nodejs12x:2.0.1165-501
           privileged: true
           requestCpu: "400m"
           requestMemory: "512Mi"
@@ -1145,7 +1145,7 @@ podTemplates:
           requestMemory: "128Mi"
           args: '${computer.jnlpmac} ${computer.name}'
         Nodejs:
-          image: gcr.io/jenkinsxio/builder-php5x:2.0.876-229
+          image: gcr.io/jenkinsxio/builder-php5x:2.0.1165-501
           privileged: true
           requestCpu: "400m"
           requestMemory: "512Mi"
@@ -1181,7 +1181,7 @@ podTemplates:
           requestMemory: "128Mi"
           args: '${computer.jnlpmac} ${computer.name}'
         Nodejs:
-          image: gcr.io/jenkinsxio/builder-php7x:2.0.876-229
+          image: gcr.io/jenkinsxio/builder-php7x:2.0.1165-501
           privileged: true
           requestCpu: "400m"
           requestMemory: "512Mi"
@@ -1228,7 +1228,7 @@ podTemplates:
           requestMemory: "128Mi"
           args: '${computer.jnlpmac} ${computer.name}'
         Nodejs:
-          image: gcr.io/jenkinsxio/builder-nodejs:2.0.876-229
+          image: gcr.io/jenkinsxio/builder-nodejs:2.0.1165-501
           privileged: true
           requestCpu: "400m"
           requestMemory: "512Mi"
@@ -1271,7 +1271,7 @@ podTemplates:
           requestMemory: "128Mi"
           args: '${computer.jnlpmac} ${computer.name}'
         MavenNodejs:
-          image: gcr.io/jenkinsxio/builder-maven-nodejs:2.0.876-229
+          image: gcr.io/jenkinsxio/builder-maven-nodejs:2.0.1165-501
           privileged: true
           requestCpu: "400m"
           requestMemory: "512Mi"
@@ -1314,7 +1314,7 @@ podTemplates:
           requestMemory: "128Mi"
           args: '${computer.jnlpmac} ${computer.name}'
         JX-base:
-          image: gcr.io/jenkinsxio/builder-jx:2.0.876-229
+          image: gcr.io/jenkinsxio/builder-jx:2.0.1165-501
           privileged: true
           requestCpu: "200m"
           requestMemory: "256Mi"
@@ -1359,7 +1359,7 @@ podTemplates:
           requestMemory: "128Mi"
           args: '${computer.jnlpmac} ${computer.name}'
         Promote:
-          image: gcr.io/jenkinsxio/builder-jx:2.0.876-229
+          image: gcr.io/jenkinsxio/builder-jx:2.0.1165-501
           privileged: true
           requestCpu: "200m"
           requestMemory: "100Mi"
@@ -1440,7 +1440,7 @@ podTemplates:
           requestMemory: "128Mi"
           args: '${computer.jnlpmac} ${computer.name}'
         Python:
-          image: gcr.io/jenkinsxio/builder-python2:2.0.876-229
+          image: gcr.io/jenkinsxio/builder-python2:2.0.1165-501
           privileged: true
           requestCpu: "400m"
           requestMemory: "512Mi"
@@ -1487,7 +1487,7 @@ podTemplates:
           requestMemory: "128Mi"
           args: '${computer.jnlpmac} ${computer.name}'
         Python:
-          image: gcr.io/jenkinsxio/builder-python:2.0.876-229
+          image: gcr.io/jenkinsxio/builder-python:2.0.1165-501
           privileged: true
           requestCpu: "400m"
           requestMemory: "512Mi"
@@ -1534,7 +1534,7 @@ podTemplates:
           requestMemory: "128Mi"
           args: '${computer.jnlpmac} ${computer.name}'
         Python:
-          image: gcr.io/jenkinsxio/builder-python37:2.0.876-229
+          image: gcr.io/jenkinsxio/builder-python37:2.0.1165-501
           privileged: true
           requestCpu: "400m"
           requestMemory: "512Mi"
@@ -1581,7 +1581,7 @@ podTemplates:
           requestMemory: "128Mi"
           args: '${computer.jnlpmac} ${computer.name}'
         Ruby:
-          image: gcr.io/jenkinsxio/builder-ruby:2.0.876-229
+          image: gcr.io/jenkinsxio/builder-ruby:2.0.1165-501
           privileged: true
           requestCpu: "400m"
           requestMemory: "512Mi"
@@ -1628,7 +1628,7 @@ podTemplates:
           requestMemory: "128Mi"
           args: '${computer.jnlpmac} ${computer.name}'
         Swift:
-          image: gcr.io/jenkinsxio/builder-swift:2.0.876-229
+          image: gcr.io/jenkinsxio/builder-swift:2.0.1165-501
           privileged: true
           requestCpu: "400m"
           requestMemory: "512Mi"
@@ -1674,7 +1674,7 @@ podTemplates:
           requestMemory: "128Mi"
           args: '${computer.jnlpmac} ${computer.name}'
         Dlang:
-          image: gcr.io/jenkinsxio/builder-dlang:2.0.876-229
+          image: gcr.io/jenkinsxio/builder-dlang:2.0.1165-501
           privileged: true
           requestCpu: "500m"
           requestMemory: "1024Mi"
@@ -1721,7 +1721,7 @@ podTemplates:
           requestMemory: "128Mi"
           args: '${computer.jnlpmac} ${computer.name}'
         Machine-Learning:
-          image: gcr.io/jenkinsxio/builder-machine-learning:0.1.837
+          image: gcr.io/jenkinsxio/builder-machine-learning:2.0.1165-501
           privileged: true
           requestCpu: "2000m"
           requestMemory: "4Gi"
@@ -1768,7 +1768,7 @@ podTemplates:
           requestMemory: "128Mi"
           args: '${computer.jnlpmac} ${computer.name}'
         Machine-Learning:
-          image: gcr.io/jenkinsxio/builder-machine-learning-gpu:0.1.837
+          image: gcr.io/jenkinsxio/builder-machine-learning-gpu:2.0.1165-501
           privileged: true
           requestCpu: "1000m"
           requestMemory: "1Gi"


### PR DESCRIPTION
Update [jenkins-x/jenkins-x-builders](https://github.com/jenkins-x/jenkins-x-builders) from 0.1.560, 0.1.837, 2.0.876-229 to [2.0.1165-501](https://github.com/jenkins-x/jenkins-x-builders/releases/tag/v2.0.1165-501)

Command run was `jx step create pr regex --regex (?m)^\s+image: gcr.io/jenkinsxio/builder-[\w-_]+:(?P<version>.*)$ --version 2.0.1165-501 --files jxboot-helmfile-resources/values.yaml --repo https://github.com/jenkins-x-charts/jxboot-helmfile-resources.git`