### PR TITLE
fix: lets still create ingress resources even if using istio ingress

### DIFF
--- a/jxboot-helmfile-resources/templates/700-bucketrepo-ing.yaml
+++ b/jxboot-helmfile-resources/templates/700-bucketrepo-ing.yaml
@@ -1,4 +1,4 @@
-{{- if and (eq "bucketrepo" .Values.jxRequirements.repository) (not (eq "istio" .Values.jxRequirements.ingress.kind)) }}
+{{- if (eq "bucketrepo" .Values.jxRequirements.repository) }}
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:

--- a/jxboot-helmfile-resources/templates/700-chartmuseum-ing.yaml
+++ b/jxboot-helmfile-resources/templates/700-chartmuseum-ing.yaml
@@ -1,4 +1,4 @@
-{{- if and (eq "nexus" .Values.jxRequirements.repository) (not (eq "istio" .Values.jxRequirements.ingress.kind)) }}
+{{- if (eq "nexus" .Values.jxRequirements.repository) }}
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:

--- a/jxboot-helmfile-resources/templates/700-docker-ing.yaml
+++ b/jxboot-helmfile-resources/templates/700-docker-ing.yaml
@@ -1,4 +1,4 @@
-{{- if and (index .Values "docker-registry" "enabled") (not (eq "istio" .Values.jxRequirements.ingress.kind))  }}
+{{- if (index .Values "docker-registry" "enabled")  }}
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:

--- a/jxboot-helmfile-resources/templates/700-hook-ing.yaml
+++ b/jxboot-helmfile-resources/templates/700-hook-ing.yaml
@@ -1,4 +1,4 @@
-{{- if and (or (eq "lighthouse" .Values.jxRequirements.webhook) (eq "prow" .Values.jxRequirements.webhook)) (not (eq "istio" .Values.jxRequirements.ingress.kind))  }}
+{{- if or (eq "lighthouse" .Values.jxRequirements.webhook) (eq "prow" .Values.jxRequirements.webhook) }}
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:

--- a/jxboot-helmfile-resources/templates/700-nexus-ing.yaml
+++ b/jxboot-helmfile-resources/templates/700-nexus-ing.yaml
@@ -1,4 +1,4 @@
-{{- if and (eq "nexus" .Values.jxRequirements.repository) (not (eq "istio" .Values.jxRequirements.ingress.kind)) }}
+{{- if (eq "nexus" .Values.jxRequirements.repository) }}
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:

--- a/tests/test_data/custom-env/expected/v1/ConfigMap/jenkins-x-pod-template-aws-cdk.yaml
+++ b/tests/test_data/custom-env/expected/v1/ConfigMap/jenkins-x-pod-template-aws-cdk.yaml
@@ -28,7 +28,7 @@ data:
           secretName: jenkins-release-gpg
       containers:
       - name: aws-cdk
-        image: gcr.io/jenkinsxio/builder-maven-nodejs:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-maven-nodejs:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/custom-env/expected/v1/ConfigMap/jenkins-x-pod-template-dlang.yaml
+++ b/tests/test_data/custom-env/expected/v1/ConfigMap/jenkins-x-pod-template-dlang.yaml
@@ -22,7 +22,7 @@ data:
         emptyDir: {}
       containers:
       - name: dlang
-        image: gcr.io/jenkinsxio/builder-dlang:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-dlang:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/custom-env/expected/v1/ConfigMap/jenkins-x-pod-template-gradle.yaml
+++ b/tests/test_data/custom-env/expected/v1/ConfigMap/jenkins-x-pod-template-gradle.yaml
@@ -25,7 +25,7 @@ data:
           secretName: jenkins-release-gpg
       containers:
       - name: gradle
-        image: gcr.io/jenkinsxio/builder-gradle:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-gradle:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/custom-env/expected/v1/ConfigMap/jenkins-x-pod-template-jx-base.yaml
+++ b/tests/test_data/custom-env/expected/v1/ConfigMap/jenkins-x-pod-template-jx-base.yaml
@@ -22,7 +22,7 @@ data:
         emptyDir: {}
       containers:
       - name: jx-base
-        image: gcr.io/jenkinsxio/builder-jx:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-jx:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/custom-env/expected/v1/ConfigMap/jenkins-x-pod-template-machine-learning-gpu.yaml
+++ b/tests/test_data/custom-env/expected/v1/ConfigMap/jenkins-x-pod-template-machine-learning-gpu.yaml
@@ -22,7 +22,7 @@ data:
         emptyDir: {}
       containers:
       - name: machine-learning
-        image: gcr.io/jenkinsxio/builder-machine-learning-gpu:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-machine-learning-gpu:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/custom-env/expected/v1/ConfigMap/jenkins-x-pod-template-machine-learning.yaml
+++ b/tests/test_data/custom-env/expected/v1/ConfigMap/jenkins-x-pod-template-machine-learning.yaml
@@ -22,7 +22,7 @@ data:
         emptyDir: {}
       containers:
       - name: machine-learning
-        image: gcr.io/jenkinsxio/builder-machine-learning:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-machine-learning:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/custom-env/expected/v1/ConfigMap/jenkins-x-pod-template-maven-graalvm.yaml
+++ b/tests/test_data/custom-env/expected/v1/ConfigMap/jenkins-x-pod-template-maven-graalvm.yaml
@@ -28,7 +28,7 @@ data:
           secretName: jenkins-release-gpg
       containers:
       - name: maven
-        image: gcr.io/jenkinsxio/builder-maven-graalvm:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-maven-graalvm:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/custom-env/expected/v1/ConfigMap/jenkins-x-pod-template-maven-java11.yaml
+++ b/tests/test_data/custom-env/expected/v1/ConfigMap/jenkins-x-pod-template-maven-java11.yaml
@@ -28,7 +28,7 @@ data:
           secretName: jenkins-release-gpg
       containers:
       - name: maven
-        image: gcr.io/jenkinsxio/builder-maven-java11:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-maven-java11:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/custom-env/expected/v1/ConfigMap/jenkins-x-pod-template-maven-nodejs.yaml
+++ b/tests/test_data/custom-env/expected/v1/ConfigMap/jenkins-x-pod-template-maven-nodejs.yaml
@@ -28,7 +28,7 @@ data:
           secretName: jenkins-release-gpg
       containers:
       - name: mavennodejs
-        image: gcr.io/jenkinsxio/builder-maven-nodejs:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-maven-nodejs:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/custom-env/expected/v1/ConfigMap/jenkins-x-pod-template-maven.yaml
+++ b/tests/test_data/custom-env/expected/v1/ConfigMap/jenkins-x-pod-template-maven.yaml
@@ -28,7 +28,7 @@ data:
           secretName: jenkins-release-gpg
       containers:
       - name: maven
-        image: gcr.io/jenkinsxio/builder-maven:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-maven:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/custom-env/expected/v1/ConfigMap/jenkins-x-pod-template-newman.yaml
+++ b/tests/test_data/custom-env/expected/v1/ConfigMap/jenkins-x-pod-template-newman.yaml
@@ -22,7 +22,7 @@ data:
         emptyDir: {}
       containers:
       - name: newman
-        image: gcr.io/jenkinsxio/builder-newman:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-newman:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/custom-env/expected/v1/ConfigMap/jenkins-x-pod-template-nodejs.yaml
+++ b/tests/test_data/custom-env/expected/v1/ConfigMap/jenkins-x-pod-template-nodejs.yaml
@@ -22,7 +22,7 @@ data:
         emptyDir: {}
       containers:
       - name: nodejs
-        image: gcr.io/jenkinsxio/builder-nodejs:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-nodejs:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/custom-env/expected/v1/ConfigMap/jenkins-x-pod-template-nodejs10x.yaml
+++ b/tests/test_data/custom-env/expected/v1/ConfigMap/jenkins-x-pod-template-nodejs10x.yaml
@@ -22,7 +22,7 @@ data:
         emptyDir: {}
       containers:
       - name: nodejs
-        image: gcr.io/jenkinsxio/builder-nodejs10x:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-nodejs10x:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/custom-env/expected/v1/ConfigMap/jenkins-x-pod-template-nodejs12x.yaml
+++ b/tests/test_data/custom-env/expected/v1/ConfigMap/jenkins-x-pod-template-nodejs12x.yaml
@@ -22,7 +22,7 @@ data:
         emptyDir: {}
       containers:
       - name: nodejs
-        image: gcr.io/jenkinsxio/builder-nodejs12x:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-nodejs12x:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/custom-env/expected/v1/ConfigMap/jenkins-x-pod-template-nodejs8x.yaml
+++ b/tests/test_data/custom-env/expected/v1/ConfigMap/jenkins-x-pod-template-nodejs8x.yaml
@@ -22,7 +22,7 @@ data:
         emptyDir: {}
       containers:
       - name: nodejs
-        image: gcr.io/jenkinsxio/builder-nodejs8x:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-nodejs8x:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/custom-env/expected/v1/ConfigMap/jenkins-x-pod-template-php5x.yaml
+++ b/tests/test_data/custom-env/expected/v1/ConfigMap/jenkins-x-pod-template-php5x.yaml
@@ -22,7 +22,7 @@ data:
         emptyDir: {}
       containers:
       - name: nodejs
-        image: gcr.io/jenkinsxio/builder-php5x:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-php5x:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/custom-env/expected/v1/ConfigMap/jenkins-x-pod-template-php7x.yaml
+++ b/tests/test_data/custom-env/expected/v1/ConfigMap/jenkins-x-pod-template-php7x.yaml
@@ -22,7 +22,7 @@ data:
         emptyDir: {}
       containers:
       - name: nodejs
-        image: gcr.io/jenkinsxio/builder-php7x:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-php7x:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/custom-env/expected/v1/ConfigMap/jenkins-x-pod-template-promote.yaml
+++ b/tests/test_data/custom-env/expected/v1/ConfigMap/jenkins-x-pod-template-promote.yaml
@@ -22,7 +22,7 @@ data:
         emptyDir: {}
       containers:
       - name: promote
-        image: gcr.io/jenkinsxio/builder-jx:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-jx:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/custom-env/expected/v1/ConfigMap/jenkins-x-pod-template-python.yaml
+++ b/tests/test_data/custom-env/expected/v1/ConfigMap/jenkins-x-pod-template-python.yaml
@@ -22,7 +22,7 @@ data:
         emptyDir: {}
       containers:
       - name: python
-        image: gcr.io/jenkinsxio/builder-python:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-python:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/custom-env/expected/v1/ConfigMap/jenkins-x-pod-template-python2.yaml
+++ b/tests/test_data/custom-env/expected/v1/ConfigMap/jenkins-x-pod-template-python2.yaml
@@ -22,7 +22,7 @@ data:
         emptyDir: {}
       containers:
       - name: python
-        image: gcr.io/jenkinsxio/builder-python2:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-python2:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/custom-env/expected/v1/ConfigMap/jenkins-x-pod-template-python37.yaml
+++ b/tests/test_data/custom-env/expected/v1/ConfigMap/jenkins-x-pod-template-python37.yaml
@@ -22,7 +22,7 @@ data:
         emptyDir: {}
       containers:
       - name: python
-        image: gcr.io/jenkinsxio/builder-python37:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-python37:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/custom-env/expected/v1/ConfigMap/jenkins-x-pod-template-ruby.yaml
+++ b/tests/test_data/custom-env/expected/v1/ConfigMap/jenkins-x-pod-template-ruby.yaml
@@ -22,7 +22,7 @@ data:
         emptyDir: {}
       containers:
       - name: ruby
-        image: gcr.io/jenkinsxio/builder-ruby:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-ruby:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/custom-env/expected/v1/ConfigMap/jenkins-x-pod-template-rust.yaml
+++ b/tests/test_data/custom-env/expected/v1/ConfigMap/jenkins-x-pod-template-rust.yaml
@@ -22,7 +22,7 @@ data:
         emptyDir: {}
       containers:
       - name: rust
-        image: gcr.io/jenkinsxio/builder-rust:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-rust:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/custom-env/expected/v1/ConfigMap/jenkins-x-pod-template-scala.yaml
+++ b/tests/test_data/custom-env/expected/v1/ConfigMap/jenkins-x-pod-template-scala.yaml
@@ -28,7 +28,7 @@ data:
           secretName: jenkins-release-gpg
       containers:
       - name: scala
-        image: gcr.io/jenkinsxio/builder-scala:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-scala:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/custom-env/expected/v1/ConfigMap/jenkins-x-pod-template-swift.yaml
+++ b/tests/test_data/custom-env/expected/v1/ConfigMap/jenkins-x-pod-template-swift.yaml
@@ -22,7 +22,7 @@ data:
         emptyDir: {}
       containers:
       - name: swift
-        image: gcr.io/jenkinsxio/builder-swift:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-swift:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/custom-env/expected/v1/ConfigMap/jenkins-x-pod-template-terraform.yaml
+++ b/tests/test_data/custom-env/expected/v1/ConfigMap/jenkins-x-pod-template-terraform.yaml
@@ -22,7 +22,7 @@ data:
         emptyDir: {}
       containers:
       - name: terraform
-        image: gcr.io/jenkinsxio/builder-terraform:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-terraform:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/custom-ingress-secret/expected/v1/ConfigMap/jenkins-x-pod-template-aws-cdk.yaml
+++ b/tests/test_data/custom-ingress-secret/expected/v1/ConfigMap/jenkins-x-pod-template-aws-cdk.yaml
@@ -28,7 +28,7 @@ data:
           secretName: jenkins-release-gpg
       containers:
       - name: aws-cdk
-        image: gcr.io/jenkinsxio/builder-maven-nodejs:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-maven-nodejs:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/custom-ingress-secret/expected/v1/ConfigMap/jenkins-x-pod-template-dlang.yaml
+++ b/tests/test_data/custom-ingress-secret/expected/v1/ConfigMap/jenkins-x-pod-template-dlang.yaml
@@ -22,7 +22,7 @@ data:
         emptyDir: {}
       containers:
       - name: dlang
-        image: gcr.io/jenkinsxio/builder-dlang:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-dlang:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/custom-ingress-secret/expected/v1/ConfigMap/jenkins-x-pod-template-gradle.yaml
+++ b/tests/test_data/custom-ingress-secret/expected/v1/ConfigMap/jenkins-x-pod-template-gradle.yaml
@@ -25,7 +25,7 @@ data:
           secretName: jenkins-release-gpg
       containers:
       - name: gradle
-        image: gcr.io/jenkinsxio/builder-gradle:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-gradle:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/custom-ingress-secret/expected/v1/ConfigMap/jenkins-x-pod-template-jx-base.yaml
+++ b/tests/test_data/custom-ingress-secret/expected/v1/ConfigMap/jenkins-x-pod-template-jx-base.yaml
@@ -22,7 +22,7 @@ data:
         emptyDir: {}
       containers:
       - name: jx-base
-        image: gcr.io/jenkinsxio/builder-jx:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-jx:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/custom-ingress-secret/expected/v1/ConfigMap/jenkins-x-pod-template-machine-learning-gpu.yaml
+++ b/tests/test_data/custom-ingress-secret/expected/v1/ConfigMap/jenkins-x-pod-template-machine-learning-gpu.yaml
@@ -22,7 +22,7 @@ data:
         emptyDir: {}
       containers:
       - name: machine-learning
-        image: gcr.io/jenkinsxio/builder-machine-learning-gpu:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-machine-learning-gpu:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/custom-ingress-secret/expected/v1/ConfigMap/jenkins-x-pod-template-machine-learning.yaml
+++ b/tests/test_data/custom-ingress-secret/expected/v1/ConfigMap/jenkins-x-pod-template-machine-learning.yaml
@@ -22,7 +22,7 @@ data:
         emptyDir: {}
       containers:
       - name: machine-learning
-        image: gcr.io/jenkinsxio/builder-machine-learning:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-machine-learning:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/custom-ingress-secret/expected/v1/ConfigMap/jenkins-x-pod-template-maven-graalvm.yaml
+++ b/tests/test_data/custom-ingress-secret/expected/v1/ConfigMap/jenkins-x-pod-template-maven-graalvm.yaml
@@ -28,7 +28,7 @@ data:
           secretName: jenkins-release-gpg
       containers:
       - name: maven
-        image: gcr.io/jenkinsxio/builder-maven-graalvm:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-maven-graalvm:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/custom-ingress-secret/expected/v1/ConfigMap/jenkins-x-pod-template-maven-java11.yaml
+++ b/tests/test_data/custom-ingress-secret/expected/v1/ConfigMap/jenkins-x-pod-template-maven-java11.yaml
@@ -28,7 +28,7 @@ data:
           secretName: jenkins-release-gpg
       containers:
       - name: maven
-        image: gcr.io/jenkinsxio/builder-maven-java11:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-maven-java11:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/custom-ingress-secret/expected/v1/ConfigMap/jenkins-x-pod-template-maven-nodejs.yaml
+++ b/tests/test_data/custom-ingress-secret/expected/v1/ConfigMap/jenkins-x-pod-template-maven-nodejs.yaml
@@ -28,7 +28,7 @@ data:
           secretName: jenkins-release-gpg
       containers:
       - name: mavennodejs
-        image: gcr.io/jenkinsxio/builder-maven-nodejs:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-maven-nodejs:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/custom-ingress-secret/expected/v1/ConfigMap/jenkins-x-pod-template-maven.yaml
+++ b/tests/test_data/custom-ingress-secret/expected/v1/ConfigMap/jenkins-x-pod-template-maven.yaml
@@ -28,7 +28,7 @@ data:
           secretName: jenkins-release-gpg
       containers:
       - name: maven
-        image: gcr.io/jenkinsxio/builder-maven:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-maven:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/custom-ingress-secret/expected/v1/ConfigMap/jenkins-x-pod-template-newman.yaml
+++ b/tests/test_data/custom-ingress-secret/expected/v1/ConfigMap/jenkins-x-pod-template-newman.yaml
@@ -22,7 +22,7 @@ data:
         emptyDir: {}
       containers:
       - name: newman
-        image: gcr.io/jenkinsxio/builder-newman:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-newman:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/custom-ingress-secret/expected/v1/ConfigMap/jenkins-x-pod-template-nodejs.yaml
+++ b/tests/test_data/custom-ingress-secret/expected/v1/ConfigMap/jenkins-x-pod-template-nodejs.yaml
@@ -22,7 +22,7 @@ data:
         emptyDir: {}
       containers:
       - name: nodejs
-        image: gcr.io/jenkinsxio/builder-nodejs:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-nodejs:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/custom-ingress-secret/expected/v1/ConfigMap/jenkins-x-pod-template-nodejs10x.yaml
+++ b/tests/test_data/custom-ingress-secret/expected/v1/ConfigMap/jenkins-x-pod-template-nodejs10x.yaml
@@ -22,7 +22,7 @@ data:
         emptyDir: {}
       containers:
       - name: nodejs
-        image: gcr.io/jenkinsxio/builder-nodejs10x:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-nodejs10x:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/custom-ingress-secret/expected/v1/ConfigMap/jenkins-x-pod-template-nodejs12x.yaml
+++ b/tests/test_data/custom-ingress-secret/expected/v1/ConfigMap/jenkins-x-pod-template-nodejs12x.yaml
@@ -22,7 +22,7 @@ data:
         emptyDir: {}
       containers:
       - name: nodejs
-        image: gcr.io/jenkinsxio/builder-nodejs12x:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-nodejs12x:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/custom-ingress-secret/expected/v1/ConfigMap/jenkins-x-pod-template-nodejs8x.yaml
+++ b/tests/test_data/custom-ingress-secret/expected/v1/ConfigMap/jenkins-x-pod-template-nodejs8x.yaml
@@ -22,7 +22,7 @@ data:
         emptyDir: {}
       containers:
       - name: nodejs
-        image: gcr.io/jenkinsxio/builder-nodejs8x:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-nodejs8x:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/custom-ingress-secret/expected/v1/ConfigMap/jenkins-x-pod-template-php5x.yaml
+++ b/tests/test_data/custom-ingress-secret/expected/v1/ConfigMap/jenkins-x-pod-template-php5x.yaml
@@ -22,7 +22,7 @@ data:
         emptyDir: {}
       containers:
       - name: nodejs
-        image: gcr.io/jenkinsxio/builder-php5x:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-php5x:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/custom-ingress-secret/expected/v1/ConfigMap/jenkins-x-pod-template-php7x.yaml
+++ b/tests/test_data/custom-ingress-secret/expected/v1/ConfigMap/jenkins-x-pod-template-php7x.yaml
@@ -22,7 +22,7 @@ data:
         emptyDir: {}
       containers:
       - name: nodejs
-        image: gcr.io/jenkinsxio/builder-php7x:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-php7x:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/custom-ingress-secret/expected/v1/ConfigMap/jenkins-x-pod-template-promote.yaml
+++ b/tests/test_data/custom-ingress-secret/expected/v1/ConfigMap/jenkins-x-pod-template-promote.yaml
@@ -22,7 +22,7 @@ data:
         emptyDir: {}
       containers:
       - name: promote
-        image: gcr.io/jenkinsxio/builder-jx:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-jx:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/custom-ingress-secret/expected/v1/ConfigMap/jenkins-x-pod-template-python.yaml
+++ b/tests/test_data/custom-ingress-secret/expected/v1/ConfigMap/jenkins-x-pod-template-python.yaml
@@ -22,7 +22,7 @@ data:
         emptyDir: {}
       containers:
       - name: python
-        image: gcr.io/jenkinsxio/builder-python:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-python:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/custom-ingress-secret/expected/v1/ConfigMap/jenkins-x-pod-template-python2.yaml
+++ b/tests/test_data/custom-ingress-secret/expected/v1/ConfigMap/jenkins-x-pod-template-python2.yaml
@@ -22,7 +22,7 @@ data:
         emptyDir: {}
       containers:
       - name: python
-        image: gcr.io/jenkinsxio/builder-python2:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-python2:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/custom-ingress-secret/expected/v1/ConfigMap/jenkins-x-pod-template-python37.yaml
+++ b/tests/test_data/custom-ingress-secret/expected/v1/ConfigMap/jenkins-x-pod-template-python37.yaml
@@ -22,7 +22,7 @@ data:
         emptyDir: {}
       containers:
       - name: python
-        image: gcr.io/jenkinsxio/builder-python37:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-python37:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/custom-ingress-secret/expected/v1/ConfigMap/jenkins-x-pod-template-ruby.yaml
+++ b/tests/test_data/custom-ingress-secret/expected/v1/ConfigMap/jenkins-x-pod-template-ruby.yaml
@@ -22,7 +22,7 @@ data:
         emptyDir: {}
       containers:
       - name: ruby
-        image: gcr.io/jenkinsxio/builder-ruby:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-ruby:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/custom-ingress-secret/expected/v1/ConfigMap/jenkins-x-pod-template-rust.yaml
+++ b/tests/test_data/custom-ingress-secret/expected/v1/ConfigMap/jenkins-x-pod-template-rust.yaml
@@ -22,7 +22,7 @@ data:
         emptyDir: {}
       containers:
       - name: rust
-        image: gcr.io/jenkinsxio/builder-rust:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-rust:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/custom-ingress-secret/expected/v1/ConfigMap/jenkins-x-pod-template-scala.yaml
+++ b/tests/test_data/custom-ingress-secret/expected/v1/ConfigMap/jenkins-x-pod-template-scala.yaml
@@ -28,7 +28,7 @@ data:
           secretName: jenkins-release-gpg
       containers:
       - name: scala
-        image: gcr.io/jenkinsxio/builder-scala:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-scala:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/custom-ingress-secret/expected/v1/ConfigMap/jenkins-x-pod-template-swift.yaml
+++ b/tests/test_data/custom-ingress-secret/expected/v1/ConfigMap/jenkins-x-pod-template-swift.yaml
@@ -22,7 +22,7 @@ data:
         emptyDir: {}
       containers:
       - name: swift
-        image: gcr.io/jenkinsxio/builder-swift:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-swift:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/custom-ingress-secret/expected/v1/ConfigMap/jenkins-x-pod-template-terraform.yaml
+++ b/tests/test_data/custom-ingress-secret/expected/v1/ConfigMap/jenkins-x-pod-template-terraform.yaml
@@ -22,7 +22,7 @@ data:
         emptyDir: {}
       containers:
       - name: terraform
-        image: gcr.io/jenkinsxio/builder-terraform:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-terraform:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/default/expected/v1/ConfigMap/jenkins-x-pod-template-aws-cdk.yaml
+++ b/tests/test_data/default/expected/v1/ConfigMap/jenkins-x-pod-template-aws-cdk.yaml
@@ -28,7 +28,7 @@ data:
           secretName: jenkins-release-gpg
       containers:
       - name: aws-cdk
-        image: gcr.io/jenkinsxio/builder-maven-nodejs:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-maven-nodejs:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/default/expected/v1/ConfigMap/jenkins-x-pod-template-dlang.yaml
+++ b/tests/test_data/default/expected/v1/ConfigMap/jenkins-x-pod-template-dlang.yaml
@@ -22,7 +22,7 @@ data:
         emptyDir: {}
       containers:
       - name: dlang
-        image: gcr.io/jenkinsxio/builder-dlang:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-dlang:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/default/expected/v1/ConfigMap/jenkins-x-pod-template-gradle.yaml
+++ b/tests/test_data/default/expected/v1/ConfigMap/jenkins-x-pod-template-gradle.yaml
@@ -25,7 +25,7 @@ data:
           secretName: jenkins-release-gpg
       containers:
       - name: gradle
-        image: gcr.io/jenkinsxio/builder-gradle:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-gradle:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/default/expected/v1/ConfigMap/jenkins-x-pod-template-jx-base.yaml
+++ b/tests/test_data/default/expected/v1/ConfigMap/jenkins-x-pod-template-jx-base.yaml
@@ -22,7 +22,7 @@ data:
         emptyDir: {}
       containers:
       - name: jx-base
-        image: gcr.io/jenkinsxio/builder-jx:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-jx:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/default/expected/v1/ConfigMap/jenkins-x-pod-template-machine-learning-gpu.yaml
+++ b/tests/test_data/default/expected/v1/ConfigMap/jenkins-x-pod-template-machine-learning-gpu.yaml
@@ -22,7 +22,7 @@ data:
         emptyDir: {}
       containers:
       - name: machine-learning
-        image: gcr.io/jenkinsxio/builder-machine-learning-gpu:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-machine-learning-gpu:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/default/expected/v1/ConfigMap/jenkins-x-pod-template-machine-learning.yaml
+++ b/tests/test_data/default/expected/v1/ConfigMap/jenkins-x-pod-template-machine-learning.yaml
@@ -22,7 +22,7 @@ data:
         emptyDir: {}
       containers:
       - name: machine-learning
-        image: gcr.io/jenkinsxio/builder-machine-learning:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-machine-learning:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/default/expected/v1/ConfigMap/jenkins-x-pod-template-maven-graalvm.yaml
+++ b/tests/test_data/default/expected/v1/ConfigMap/jenkins-x-pod-template-maven-graalvm.yaml
@@ -28,7 +28,7 @@ data:
           secretName: jenkins-release-gpg
       containers:
       - name: maven
-        image: gcr.io/jenkinsxio/builder-maven-graalvm:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-maven-graalvm:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/default/expected/v1/ConfigMap/jenkins-x-pod-template-maven-java11.yaml
+++ b/tests/test_data/default/expected/v1/ConfigMap/jenkins-x-pod-template-maven-java11.yaml
@@ -28,7 +28,7 @@ data:
           secretName: jenkins-release-gpg
       containers:
       - name: maven
-        image: gcr.io/jenkinsxio/builder-maven-java11:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-maven-java11:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/default/expected/v1/ConfigMap/jenkins-x-pod-template-maven-nodejs.yaml
+++ b/tests/test_data/default/expected/v1/ConfigMap/jenkins-x-pod-template-maven-nodejs.yaml
@@ -28,7 +28,7 @@ data:
           secretName: jenkins-release-gpg
       containers:
       - name: mavennodejs
-        image: gcr.io/jenkinsxio/builder-maven-nodejs:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-maven-nodejs:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/default/expected/v1/ConfigMap/jenkins-x-pod-template-maven.yaml
+++ b/tests/test_data/default/expected/v1/ConfigMap/jenkins-x-pod-template-maven.yaml
@@ -28,7 +28,7 @@ data:
           secretName: jenkins-release-gpg
       containers:
       - name: maven
-        image: gcr.io/jenkinsxio/builder-maven:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-maven:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/default/expected/v1/ConfigMap/jenkins-x-pod-template-newman.yaml
+++ b/tests/test_data/default/expected/v1/ConfigMap/jenkins-x-pod-template-newman.yaml
@@ -22,7 +22,7 @@ data:
         emptyDir: {}
       containers:
       - name: newman
-        image: gcr.io/jenkinsxio/builder-newman:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-newman:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/default/expected/v1/ConfigMap/jenkins-x-pod-template-nodejs.yaml
+++ b/tests/test_data/default/expected/v1/ConfigMap/jenkins-x-pod-template-nodejs.yaml
@@ -22,7 +22,7 @@ data:
         emptyDir: {}
       containers:
       - name: nodejs
-        image: gcr.io/jenkinsxio/builder-nodejs:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-nodejs:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/default/expected/v1/ConfigMap/jenkins-x-pod-template-nodejs10x.yaml
+++ b/tests/test_data/default/expected/v1/ConfigMap/jenkins-x-pod-template-nodejs10x.yaml
@@ -22,7 +22,7 @@ data:
         emptyDir: {}
       containers:
       - name: nodejs
-        image: gcr.io/jenkinsxio/builder-nodejs10x:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-nodejs10x:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/default/expected/v1/ConfigMap/jenkins-x-pod-template-nodejs12x.yaml
+++ b/tests/test_data/default/expected/v1/ConfigMap/jenkins-x-pod-template-nodejs12x.yaml
@@ -22,7 +22,7 @@ data:
         emptyDir: {}
       containers:
       - name: nodejs
-        image: gcr.io/jenkinsxio/builder-nodejs12x:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-nodejs12x:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/default/expected/v1/ConfigMap/jenkins-x-pod-template-nodejs8x.yaml
+++ b/tests/test_data/default/expected/v1/ConfigMap/jenkins-x-pod-template-nodejs8x.yaml
@@ -22,7 +22,7 @@ data:
         emptyDir: {}
       containers:
       - name: nodejs
-        image: gcr.io/jenkinsxio/builder-nodejs8x:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-nodejs8x:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/default/expected/v1/ConfigMap/jenkins-x-pod-template-php5x.yaml
+++ b/tests/test_data/default/expected/v1/ConfigMap/jenkins-x-pod-template-php5x.yaml
@@ -22,7 +22,7 @@ data:
         emptyDir: {}
       containers:
       - name: nodejs
-        image: gcr.io/jenkinsxio/builder-php5x:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-php5x:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/default/expected/v1/ConfigMap/jenkins-x-pod-template-php7x.yaml
+++ b/tests/test_data/default/expected/v1/ConfigMap/jenkins-x-pod-template-php7x.yaml
@@ -22,7 +22,7 @@ data:
         emptyDir: {}
       containers:
       - name: nodejs
-        image: gcr.io/jenkinsxio/builder-php7x:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-php7x:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/default/expected/v1/ConfigMap/jenkins-x-pod-template-promote.yaml
+++ b/tests/test_data/default/expected/v1/ConfigMap/jenkins-x-pod-template-promote.yaml
@@ -22,7 +22,7 @@ data:
         emptyDir: {}
       containers:
       - name: promote
-        image: gcr.io/jenkinsxio/builder-jx:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-jx:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/default/expected/v1/ConfigMap/jenkins-x-pod-template-python.yaml
+++ b/tests/test_data/default/expected/v1/ConfigMap/jenkins-x-pod-template-python.yaml
@@ -22,7 +22,7 @@ data:
         emptyDir: {}
       containers:
       - name: python
-        image: gcr.io/jenkinsxio/builder-python:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-python:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/default/expected/v1/ConfigMap/jenkins-x-pod-template-python2.yaml
+++ b/tests/test_data/default/expected/v1/ConfigMap/jenkins-x-pod-template-python2.yaml
@@ -22,7 +22,7 @@ data:
         emptyDir: {}
       containers:
       - name: python
-        image: gcr.io/jenkinsxio/builder-python2:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-python2:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/default/expected/v1/ConfigMap/jenkins-x-pod-template-python37.yaml
+++ b/tests/test_data/default/expected/v1/ConfigMap/jenkins-x-pod-template-python37.yaml
@@ -22,7 +22,7 @@ data:
         emptyDir: {}
       containers:
       - name: python
-        image: gcr.io/jenkinsxio/builder-python37:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-python37:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/default/expected/v1/ConfigMap/jenkins-x-pod-template-ruby.yaml
+++ b/tests/test_data/default/expected/v1/ConfigMap/jenkins-x-pod-template-ruby.yaml
@@ -22,7 +22,7 @@ data:
         emptyDir: {}
       containers:
       - name: ruby
-        image: gcr.io/jenkinsxio/builder-ruby:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-ruby:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/default/expected/v1/ConfigMap/jenkins-x-pod-template-rust.yaml
+++ b/tests/test_data/default/expected/v1/ConfigMap/jenkins-x-pod-template-rust.yaml
@@ -22,7 +22,7 @@ data:
         emptyDir: {}
       containers:
       - name: rust
-        image: gcr.io/jenkinsxio/builder-rust:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-rust:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/default/expected/v1/ConfigMap/jenkins-x-pod-template-scala.yaml
+++ b/tests/test_data/default/expected/v1/ConfigMap/jenkins-x-pod-template-scala.yaml
@@ -28,7 +28,7 @@ data:
           secretName: jenkins-release-gpg
       containers:
       - name: scala
-        image: gcr.io/jenkinsxio/builder-scala:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-scala:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/default/expected/v1/ConfigMap/jenkins-x-pod-template-swift.yaml
+++ b/tests/test_data/default/expected/v1/ConfigMap/jenkins-x-pod-template-swift.yaml
@@ -22,7 +22,7 @@ data:
         emptyDir: {}
       containers:
       - name: swift
-        image: gcr.io/jenkinsxio/builder-swift:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-swift:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/default/expected/v1/ConfigMap/jenkins-x-pod-template-terraform.yaml
+++ b/tests/test_data/default/expected/v1/ConfigMap/jenkins-x-pod-template-terraform.yaml
@@ -22,7 +22,7 @@ data:
         emptyDir: {}
       containers:
       - name: terraform
-        image: gcr.io/jenkinsxio/builder-terraform:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-terraform:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/gke-domain/expected/v1/ConfigMap/jenkins-x-pod-template-aws-cdk.yaml
+++ b/tests/test_data/gke-domain/expected/v1/ConfigMap/jenkins-x-pod-template-aws-cdk.yaml
@@ -28,7 +28,7 @@ data:
           secretName: jenkins-release-gpg
       containers:
       - name: aws-cdk
-        image: gcr.io/jenkinsxio/builder-maven-nodejs:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-maven-nodejs:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/gke-domain/expected/v1/ConfigMap/jenkins-x-pod-template-dlang.yaml
+++ b/tests/test_data/gke-domain/expected/v1/ConfigMap/jenkins-x-pod-template-dlang.yaml
@@ -22,7 +22,7 @@ data:
         emptyDir: {}
       containers:
       - name: dlang
-        image: gcr.io/jenkinsxio/builder-dlang:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-dlang:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/gke-domain/expected/v1/ConfigMap/jenkins-x-pod-template-gradle.yaml
+++ b/tests/test_data/gke-domain/expected/v1/ConfigMap/jenkins-x-pod-template-gradle.yaml
@@ -25,7 +25,7 @@ data:
           secretName: jenkins-release-gpg
       containers:
       - name: gradle
-        image: gcr.io/jenkinsxio/builder-gradle:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-gradle:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/gke-domain/expected/v1/ConfigMap/jenkins-x-pod-template-jx-base.yaml
+++ b/tests/test_data/gke-domain/expected/v1/ConfigMap/jenkins-x-pod-template-jx-base.yaml
@@ -22,7 +22,7 @@ data:
         emptyDir: {}
       containers:
       - name: jx-base
-        image: gcr.io/jenkinsxio/builder-jx:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-jx:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/gke-domain/expected/v1/ConfigMap/jenkins-x-pod-template-machine-learning-gpu.yaml
+++ b/tests/test_data/gke-domain/expected/v1/ConfigMap/jenkins-x-pod-template-machine-learning-gpu.yaml
@@ -22,7 +22,7 @@ data:
         emptyDir: {}
       containers:
       - name: machine-learning
-        image: gcr.io/jenkinsxio/builder-machine-learning-gpu:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-machine-learning-gpu:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/gke-domain/expected/v1/ConfigMap/jenkins-x-pod-template-machine-learning.yaml
+++ b/tests/test_data/gke-domain/expected/v1/ConfigMap/jenkins-x-pod-template-machine-learning.yaml
@@ -22,7 +22,7 @@ data:
         emptyDir: {}
       containers:
       - name: machine-learning
-        image: gcr.io/jenkinsxio/builder-machine-learning:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-machine-learning:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/gke-domain/expected/v1/ConfigMap/jenkins-x-pod-template-maven-graalvm.yaml
+++ b/tests/test_data/gke-domain/expected/v1/ConfigMap/jenkins-x-pod-template-maven-graalvm.yaml
@@ -28,7 +28,7 @@ data:
           secretName: jenkins-release-gpg
       containers:
       - name: maven
-        image: gcr.io/jenkinsxio/builder-maven-graalvm:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-maven-graalvm:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/gke-domain/expected/v1/ConfigMap/jenkins-x-pod-template-maven-java11.yaml
+++ b/tests/test_data/gke-domain/expected/v1/ConfigMap/jenkins-x-pod-template-maven-java11.yaml
@@ -28,7 +28,7 @@ data:
           secretName: jenkins-release-gpg
       containers:
       - name: maven
-        image: gcr.io/jenkinsxio/builder-maven-java11:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-maven-java11:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/gke-domain/expected/v1/ConfigMap/jenkins-x-pod-template-maven-nodejs.yaml
+++ b/tests/test_data/gke-domain/expected/v1/ConfigMap/jenkins-x-pod-template-maven-nodejs.yaml
@@ -28,7 +28,7 @@ data:
           secretName: jenkins-release-gpg
       containers:
       - name: mavennodejs
-        image: gcr.io/jenkinsxio/builder-maven-nodejs:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-maven-nodejs:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/gke-domain/expected/v1/ConfigMap/jenkins-x-pod-template-maven.yaml
+++ b/tests/test_data/gke-domain/expected/v1/ConfigMap/jenkins-x-pod-template-maven.yaml
@@ -28,7 +28,7 @@ data:
           secretName: jenkins-release-gpg
       containers:
       - name: maven
-        image: gcr.io/jenkinsxio/builder-maven:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-maven:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/gke-domain/expected/v1/ConfigMap/jenkins-x-pod-template-newman.yaml
+++ b/tests/test_data/gke-domain/expected/v1/ConfigMap/jenkins-x-pod-template-newman.yaml
@@ -22,7 +22,7 @@ data:
         emptyDir: {}
       containers:
       - name: newman
-        image: gcr.io/jenkinsxio/builder-newman:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-newman:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/gke-domain/expected/v1/ConfigMap/jenkins-x-pod-template-nodejs.yaml
+++ b/tests/test_data/gke-domain/expected/v1/ConfigMap/jenkins-x-pod-template-nodejs.yaml
@@ -22,7 +22,7 @@ data:
         emptyDir: {}
       containers:
       - name: nodejs
-        image: gcr.io/jenkinsxio/builder-nodejs:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-nodejs:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/gke-domain/expected/v1/ConfigMap/jenkins-x-pod-template-nodejs10x.yaml
+++ b/tests/test_data/gke-domain/expected/v1/ConfigMap/jenkins-x-pod-template-nodejs10x.yaml
@@ -22,7 +22,7 @@ data:
         emptyDir: {}
       containers:
       - name: nodejs
-        image: gcr.io/jenkinsxio/builder-nodejs10x:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-nodejs10x:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/gke-domain/expected/v1/ConfigMap/jenkins-x-pod-template-nodejs12x.yaml
+++ b/tests/test_data/gke-domain/expected/v1/ConfigMap/jenkins-x-pod-template-nodejs12x.yaml
@@ -22,7 +22,7 @@ data:
         emptyDir: {}
       containers:
       - name: nodejs
-        image: gcr.io/jenkinsxio/builder-nodejs12x:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-nodejs12x:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/gke-domain/expected/v1/ConfigMap/jenkins-x-pod-template-nodejs8x.yaml
+++ b/tests/test_data/gke-domain/expected/v1/ConfigMap/jenkins-x-pod-template-nodejs8x.yaml
@@ -22,7 +22,7 @@ data:
         emptyDir: {}
       containers:
       - name: nodejs
-        image: gcr.io/jenkinsxio/builder-nodejs8x:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-nodejs8x:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/gke-domain/expected/v1/ConfigMap/jenkins-x-pod-template-php5x.yaml
+++ b/tests/test_data/gke-domain/expected/v1/ConfigMap/jenkins-x-pod-template-php5x.yaml
@@ -22,7 +22,7 @@ data:
         emptyDir: {}
       containers:
       - name: nodejs
-        image: gcr.io/jenkinsxio/builder-php5x:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-php5x:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/gke-domain/expected/v1/ConfigMap/jenkins-x-pod-template-php7x.yaml
+++ b/tests/test_data/gke-domain/expected/v1/ConfigMap/jenkins-x-pod-template-php7x.yaml
@@ -22,7 +22,7 @@ data:
         emptyDir: {}
       containers:
       - name: nodejs
-        image: gcr.io/jenkinsxio/builder-php7x:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-php7x:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/gke-domain/expected/v1/ConfigMap/jenkins-x-pod-template-promote.yaml
+++ b/tests/test_data/gke-domain/expected/v1/ConfigMap/jenkins-x-pod-template-promote.yaml
@@ -22,7 +22,7 @@ data:
         emptyDir: {}
       containers:
       - name: promote
-        image: gcr.io/jenkinsxio/builder-jx:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-jx:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/gke-domain/expected/v1/ConfigMap/jenkins-x-pod-template-python.yaml
+++ b/tests/test_data/gke-domain/expected/v1/ConfigMap/jenkins-x-pod-template-python.yaml
@@ -22,7 +22,7 @@ data:
         emptyDir: {}
       containers:
       - name: python
-        image: gcr.io/jenkinsxio/builder-python:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-python:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/gke-domain/expected/v1/ConfigMap/jenkins-x-pod-template-python2.yaml
+++ b/tests/test_data/gke-domain/expected/v1/ConfigMap/jenkins-x-pod-template-python2.yaml
@@ -22,7 +22,7 @@ data:
         emptyDir: {}
       containers:
       - name: python
-        image: gcr.io/jenkinsxio/builder-python2:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-python2:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/gke-domain/expected/v1/ConfigMap/jenkins-x-pod-template-python37.yaml
+++ b/tests/test_data/gke-domain/expected/v1/ConfigMap/jenkins-x-pod-template-python37.yaml
@@ -22,7 +22,7 @@ data:
         emptyDir: {}
       containers:
       - name: python
-        image: gcr.io/jenkinsxio/builder-python37:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-python37:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/gke-domain/expected/v1/ConfigMap/jenkins-x-pod-template-ruby.yaml
+++ b/tests/test_data/gke-domain/expected/v1/ConfigMap/jenkins-x-pod-template-ruby.yaml
@@ -22,7 +22,7 @@ data:
         emptyDir: {}
       containers:
       - name: ruby
-        image: gcr.io/jenkinsxio/builder-ruby:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-ruby:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/gke-domain/expected/v1/ConfigMap/jenkins-x-pod-template-rust.yaml
+++ b/tests/test_data/gke-domain/expected/v1/ConfigMap/jenkins-x-pod-template-rust.yaml
@@ -22,7 +22,7 @@ data:
         emptyDir: {}
       containers:
       - name: rust
-        image: gcr.io/jenkinsxio/builder-rust:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-rust:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/gke-domain/expected/v1/ConfigMap/jenkins-x-pod-template-scala.yaml
+++ b/tests/test_data/gke-domain/expected/v1/ConfigMap/jenkins-x-pod-template-scala.yaml
@@ -28,7 +28,7 @@ data:
           secretName: jenkins-release-gpg
       containers:
       - name: scala
-        image: gcr.io/jenkinsxio/builder-scala:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-scala:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/gke-domain/expected/v1/ConfigMap/jenkins-x-pod-template-swift.yaml
+++ b/tests/test_data/gke-domain/expected/v1/ConfigMap/jenkins-x-pod-template-swift.yaml
@@ -22,7 +22,7 @@ data:
         emptyDir: {}
       containers:
       - name: swift
-        image: gcr.io/jenkinsxio/builder-swift:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-swift:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/gke-domain/expected/v1/ConfigMap/jenkins-x-pod-template-terraform.yaml
+++ b/tests/test_data/gke-domain/expected/v1/ConfigMap/jenkins-x-pod-template-terraform.yaml
@@ -22,7 +22,7 @@ data:
         emptyDir: {}
       containers:
       - name: terraform
-        image: gcr.io/jenkinsxio/builder-terraform:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-terraform:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/gke/expected/v1/ConfigMap/jenkins-x-pod-template-aws-cdk.yaml
+++ b/tests/test_data/gke/expected/v1/ConfigMap/jenkins-x-pod-template-aws-cdk.yaml
@@ -28,7 +28,7 @@ data:
           secretName: jenkins-release-gpg
       containers:
       - name: aws-cdk
-        image: gcr.io/jenkinsxio/builder-maven-nodejs:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-maven-nodejs:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/gke/expected/v1/ConfigMap/jenkins-x-pod-template-dlang.yaml
+++ b/tests/test_data/gke/expected/v1/ConfigMap/jenkins-x-pod-template-dlang.yaml
@@ -22,7 +22,7 @@ data:
         emptyDir: {}
       containers:
       - name: dlang
-        image: gcr.io/jenkinsxio/builder-dlang:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-dlang:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/gke/expected/v1/ConfigMap/jenkins-x-pod-template-gradle.yaml
+++ b/tests/test_data/gke/expected/v1/ConfigMap/jenkins-x-pod-template-gradle.yaml
@@ -25,7 +25,7 @@ data:
           secretName: jenkins-release-gpg
       containers:
       - name: gradle
-        image: gcr.io/jenkinsxio/builder-gradle:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-gradle:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/gke/expected/v1/ConfigMap/jenkins-x-pod-template-jx-base.yaml
+++ b/tests/test_data/gke/expected/v1/ConfigMap/jenkins-x-pod-template-jx-base.yaml
@@ -22,7 +22,7 @@ data:
         emptyDir: {}
       containers:
       - name: jx-base
-        image: gcr.io/jenkinsxio/builder-jx:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-jx:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/gke/expected/v1/ConfigMap/jenkins-x-pod-template-machine-learning-gpu.yaml
+++ b/tests/test_data/gke/expected/v1/ConfigMap/jenkins-x-pod-template-machine-learning-gpu.yaml
@@ -22,7 +22,7 @@ data:
         emptyDir: {}
       containers:
       - name: machine-learning
-        image: gcr.io/jenkinsxio/builder-machine-learning-gpu:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-machine-learning-gpu:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/gke/expected/v1/ConfigMap/jenkins-x-pod-template-machine-learning.yaml
+++ b/tests/test_data/gke/expected/v1/ConfigMap/jenkins-x-pod-template-machine-learning.yaml
@@ -22,7 +22,7 @@ data:
         emptyDir: {}
       containers:
       - name: machine-learning
-        image: gcr.io/jenkinsxio/builder-machine-learning:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-machine-learning:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/gke/expected/v1/ConfigMap/jenkins-x-pod-template-maven-graalvm.yaml
+++ b/tests/test_data/gke/expected/v1/ConfigMap/jenkins-x-pod-template-maven-graalvm.yaml
@@ -28,7 +28,7 @@ data:
           secretName: jenkins-release-gpg
       containers:
       - name: maven
-        image: gcr.io/jenkinsxio/builder-maven-graalvm:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-maven-graalvm:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/gke/expected/v1/ConfigMap/jenkins-x-pod-template-maven-java11.yaml
+++ b/tests/test_data/gke/expected/v1/ConfigMap/jenkins-x-pod-template-maven-java11.yaml
@@ -28,7 +28,7 @@ data:
           secretName: jenkins-release-gpg
       containers:
       - name: maven
-        image: gcr.io/jenkinsxio/builder-maven-java11:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-maven-java11:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/gke/expected/v1/ConfigMap/jenkins-x-pod-template-maven-nodejs.yaml
+++ b/tests/test_data/gke/expected/v1/ConfigMap/jenkins-x-pod-template-maven-nodejs.yaml
@@ -28,7 +28,7 @@ data:
           secretName: jenkins-release-gpg
       containers:
       - name: mavennodejs
-        image: gcr.io/jenkinsxio/builder-maven-nodejs:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-maven-nodejs:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/gke/expected/v1/ConfigMap/jenkins-x-pod-template-maven.yaml
+++ b/tests/test_data/gke/expected/v1/ConfigMap/jenkins-x-pod-template-maven.yaml
@@ -28,7 +28,7 @@ data:
           secretName: jenkins-release-gpg
       containers:
       - name: maven
-        image: gcr.io/jenkinsxio/builder-maven:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-maven:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/gke/expected/v1/ConfigMap/jenkins-x-pod-template-newman.yaml
+++ b/tests/test_data/gke/expected/v1/ConfigMap/jenkins-x-pod-template-newman.yaml
@@ -22,7 +22,7 @@ data:
         emptyDir: {}
       containers:
       - name: newman
-        image: gcr.io/jenkinsxio/builder-newman:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-newman:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/gke/expected/v1/ConfigMap/jenkins-x-pod-template-nodejs.yaml
+++ b/tests/test_data/gke/expected/v1/ConfigMap/jenkins-x-pod-template-nodejs.yaml
@@ -22,7 +22,7 @@ data:
         emptyDir: {}
       containers:
       - name: nodejs
-        image: gcr.io/jenkinsxio/builder-nodejs:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-nodejs:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/gke/expected/v1/ConfigMap/jenkins-x-pod-template-nodejs10x.yaml
+++ b/tests/test_data/gke/expected/v1/ConfigMap/jenkins-x-pod-template-nodejs10x.yaml
@@ -22,7 +22,7 @@ data:
         emptyDir: {}
       containers:
       - name: nodejs
-        image: gcr.io/jenkinsxio/builder-nodejs10x:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-nodejs10x:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/gke/expected/v1/ConfigMap/jenkins-x-pod-template-nodejs12x.yaml
+++ b/tests/test_data/gke/expected/v1/ConfigMap/jenkins-x-pod-template-nodejs12x.yaml
@@ -22,7 +22,7 @@ data:
         emptyDir: {}
       containers:
       - name: nodejs
-        image: gcr.io/jenkinsxio/builder-nodejs12x:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-nodejs12x:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/gke/expected/v1/ConfigMap/jenkins-x-pod-template-nodejs8x.yaml
+++ b/tests/test_data/gke/expected/v1/ConfigMap/jenkins-x-pod-template-nodejs8x.yaml
@@ -22,7 +22,7 @@ data:
         emptyDir: {}
       containers:
       - name: nodejs
-        image: gcr.io/jenkinsxio/builder-nodejs8x:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-nodejs8x:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/gke/expected/v1/ConfigMap/jenkins-x-pod-template-php5x.yaml
+++ b/tests/test_data/gke/expected/v1/ConfigMap/jenkins-x-pod-template-php5x.yaml
@@ -22,7 +22,7 @@ data:
         emptyDir: {}
       containers:
       - name: nodejs
-        image: gcr.io/jenkinsxio/builder-php5x:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-php5x:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/gke/expected/v1/ConfigMap/jenkins-x-pod-template-php7x.yaml
+++ b/tests/test_data/gke/expected/v1/ConfigMap/jenkins-x-pod-template-php7x.yaml
@@ -22,7 +22,7 @@ data:
         emptyDir: {}
       containers:
       - name: nodejs
-        image: gcr.io/jenkinsxio/builder-php7x:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-php7x:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/gke/expected/v1/ConfigMap/jenkins-x-pod-template-promote.yaml
+++ b/tests/test_data/gke/expected/v1/ConfigMap/jenkins-x-pod-template-promote.yaml
@@ -22,7 +22,7 @@ data:
         emptyDir: {}
       containers:
       - name: promote
-        image: gcr.io/jenkinsxio/builder-jx:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-jx:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/gke/expected/v1/ConfigMap/jenkins-x-pod-template-python.yaml
+++ b/tests/test_data/gke/expected/v1/ConfigMap/jenkins-x-pod-template-python.yaml
@@ -22,7 +22,7 @@ data:
         emptyDir: {}
       containers:
       - name: python
-        image: gcr.io/jenkinsxio/builder-python:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-python:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/gke/expected/v1/ConfigMap/jenkins-x-pod-template-python2.yaml
+++ b/tests/test_data/gke/expected/v1/ConfigMap/jenkins-x-pod-template-python2.yaml
@@ -22,7 +22,7 @@ data:
         emptyDir: {}
       containers:
       - name: python
-        image: gcr.io/jenkinsxio/builder-python2:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-python2:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/gke/expected/v1/ConfigMap/jenkins-x-pod-template-python37.yaml
+++ b/tests/test_data/gke/expected/v1/ConfigMap/jenkins-x-pod-template-python37.yaml
@@ -22,7 +22,7 @@ data:
         emptyDir: {}
       containers:
       - name: python
-        image: gcr.io/jenkinsxio/builder-python37:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-python37:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/gke/expected/v1/ConfigMap/jenkins-x-pod-template-ruby.yaml
+++ b/tests/test_data/gke/expected/v1/ConfigMap/jenkins-x-pod-template-ruby.yaml
@@ -22,7 +22,7 @@ data:
         emptyDir: {}
       containers:
       - name: ruby
-        image: gcr.io/jenkinsxio/builder-ruby:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-ruby:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/gke/expected/v1/ConfigMap/jenkins-x-pod-template-rust.yaml
+++ b/tests/test_data/gke/expected/v1/ConfigMap/jenkins-x-pod-template-rust.yaml
@@ -22,7 +22,7 @@ data:
         emptyDir: {}
       containers:
       - name: rust
-        image: gcr.io/jenkinsxio/builder-rust:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-rust:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/gke/expected/v1/ConfigMap/jenkins-x-pod-template-scala.yaml
+++ b/tests/test_data/gke/expected/v1/ConfigMap/jenkins-x-pod-template-scala.yaml
@@ -28,7 +28,7 @@ data:
           secretName: jenkins-release-gpg
       containers:
       - name: scala
-        image: gcr.io/jenkinsxio/builder-scala:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-scala:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/gke/expected/v1/ConfigMap/jenkins-x-pod-template-swift.yaml
+++ b/tests/test_data/gke/expected/v1/ConfigMap/jenkins-x-pod-template-swift.yaml
@@ -22,7 +22,7 @@ data:
         emptyDir: {}
       containers:
       - name: swift
-        image: gcr.io/jenkinsxio/builder-swift:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-swift:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/gke/expected/v1/ConfigMap/jenkins-x-pod-template-terraform.yaml
+++ b/tests/test_data/gke/expected/v1/ConfigMap/jenkins-x-pod-template-terraform.yaml
@@ -22,7 +22,7 @@ data:
         emptyDir: {}
       containers:
       - name: terraform
-        image: gcr.io/jenkinsxio/builder-terraform:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-terraform:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/istio/expected/extensions/v1beta1/Ingress/chartmuseum.yaml
+++ b/tests/test_data/istio/expected/extensions/v1beta1/Ingress/chartmuseum.yaml
@@ -1,0 +1,20 @@
+# Source: jxboot-helmfile-resources/templates/700-chartmuseum-ing.yaml
+
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: nginx
+  name: chartmuseum
+spec:
+  rules:
+  - host: chartmuseum-jx.mydomain.com
+    http:
+      paths:
+      - backend:
+          serviceName: jenkins-x-chartmuseum
+          servicePort: 8080
+  tls:
+  - hosts:
+    - chartmuseum-jx.mydomain.com
+    secretName: "my-ingress-secret"

--- a/tests/test_data/istio/expected/extensions/v1beta1/Ingress/hook.yaml
+++ b/tests/test_data/istio/expected/extensions/v1beta1/Ingress/hook.yaml
@@ -1,0 +1,20 @@
+# Source: jxboot-helmfile-resources/templates/700-hook-ing.yaml
+
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: hook
+  annotations:
+    kubernetes.io/ingress.class: nginx
+spec:
+  rules:
+  - host: hook-jx.mydomain.com
+    http:
+      paths:
+      - backend:
+          serviceName: hook
+          servicePort: 80
+  tls:
+  - hosts:
+    - hook-jx.mydomain.com
+    secretName: "my-ingress-secret"

--- a/tests/test_data/istio/expected/extensions/v1beta1/Ingress/nexus.yaml
+++ b/tests/test_data/istio/expected/extensions/v1beta1/Ingress/nexus.yaml
@@ -1,0 +1,20 @@
+# Source: jxboot-helmfile-resources/templates/700-nexus-ing.yaml
+
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: nginx
+  name: nexus
+spec:
+  rules:
+  - host: nexus-jx.mydomain.com
+    http:
+      paths:
+      - backend:
+          serviceName: nexus
+          servicePort: 80
+  tls:
+  - hosts:
+    - nexus-jx.mydomain.com
+    secretName: "my-ingress-secret"

--- a/tests/test_data/istio/expected/v1/ConfigMap/jenkins-x-pod-template-aws-cdk.yaml
+++ b/tests/test_data/istio/expected/v1/ConfigMap/jenkins-x-pod-template-aws-cdk.yaml
@@ -28,7 +28,7 @@ data:
           secretName: jenkins-release-gpg
       containers:
       - name: aws-cdk
-        image: gcr.io/jenkinsxio/builder-maven-nodejs:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-maven-nodejs:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/istio/expected/v1/ConfigMap/jenkins-x-pod-template-dlang.yaml
+++ b/tests/test_data/istio/expected/v1/ConfigMap/jenkins-x-pod-template-dlang.yaml
@@ -22,7 +22,7 @@ data:
         emptyDir: {}
       containers:
       - name: dlang
-        image: gcr.io/jenkinsxio/builder-dlang:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-dlang:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/istio/expected/v1/ConfigMap/jenkins-x-pod-template-gradle.yaml
+++ b/tests/test_data/istio/expected/v1/ConfigMap/jenkins-x-pod-template-gradle.yaml
@@ -25,7 +25,7 @@ data:
           secretName: jenkins-release-gpg
       containers:
       - name: gradle
-        image: gcr.io/jenkinsxio/builder-gradle:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-gradle:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/istio/expected/v1/ConfigMap/jenkins-x-pod-template-jx-base.yaml
+++ b/tests/test_data/istio/expected/v1/ConfigMap/jenkins-x-pod-template-jx-base.yaml
@@ -22,7 +22,7 @@ data:
         emptyDir: {}
       containers:
       - name: jx-base
-        image: gcr.io/jenkinsxio/builder-jx:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-jx:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/istio/expected/v1/ConfigMap/jenkins-x-pod-template-machine-learning-gpu.yaml
+++ b/tests/test_data/istio/expected/v1/ConfigMap/jenkins-x-pod-template-machine-learning-gpu.yaml
@@ -22,7 +22,7 @@ data:
         emptyDir: {}
       containers:
       - name: machine-learning
-        image: gcr.io/jenkinsxio/builder-machine-learning-gpu:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-machine-learning-gpu:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/istio/expected/v1/ConfigMap/jenkins-x-pod-template-machine-learning.yaml
+++ b/tests/test_data/istio/expected/v1/ConfigMap/jenkins-x-pod-template-machine-learning.yaml
@@ -22,7 +22,7 @@ data:
         emptyDir: {}
       containers:
       - name: machine-learning
-        image: gcr.io/jenkinsxio/builder-machine-learning:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-machine-learning:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/istio/expected/v1/ConfigMap/jenkins-x-pod-template-maven-graalvm.yaml
+++ b/tests/test_data/istio/expected/v1/ConfigMap/jenkins-x-pod-template-maven-graalvm.yaml
@@ -28,7 +28,7 @@ data:
           secretName: jenkins-release-gpg
       containers:
       - name: maven
-        image: gcr.io/jenkinsxio/builder-maven-graalvm:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-maven-graalvm:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/istio/expected/v1/ConfigMap/jenkins-x-pod-template-maven-java11.yaml
+++ b/tests/test_data/istio/expected/v1/ConfigMap/jenkins-x-pod-template-maven-java11.yaml
@@ -28,7 +28,7 @@ data:
           secretName: jenkins-release-gpg
       containers:
       - name: maven
-        image: gcr.io/jenkinsxio/builder-maven-java11:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-maven-java11:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/istio/expected/v1/ConfigMap/jenkins-x-pod-template-maven-nodejs.yaml
+++ b/tests/test_data/istio/expected/v1/ConfigMap/jenkins-x-pod-template-maven-nodejs.yaml
@@ -28,7 +28,7 @@ data:
           secretName: jenkins-release-gpg
       containers:
       - name: mavennodejs
-        image: gcr.io/jenkinsxio/builder-maven-nodejs:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-maven-nodejs:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/istio/expected/v1/ConfigMap/jenkins-x-pod-template-maven.yaml
+++ b/tests/test_data/istio/expected/v1/ConfigMap/jenkins-x-pod-template-maven.yaml
@@ -28,7 +28,7 @@ data:
           secretName: jenkins-release-gpg
       containers:
       - name: maven
-        image: gcr.io/jenkinsxio/builder-maven:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-maven:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/istio/expected/v1/ConfigMap/jenkins-x-pod-template-newman.yaml
+++ b/tests/test_data/istio/expected/v1/ConfigMap/jenkins-x-pod-template-newman.yaml
@@ -22,7 +22,7 @@ data:
         emptyDir: {}
       containers:
       - name: newman
-        image: gcr.io/jenkinsxio/builder-newman:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-newman:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/istio/expected/v1/ConfigMap/jenkins-x-pod-template-nodejs.yaml
+++ b/tests/test_data/istio/expected/v1/ConfigMap/jenkins-x-pod-template-nodejs.yaml
@@ -22,7 +22,7 @@ data:
         emptyDir: {}
       containers:
       - name: nodejs
-        image: gcr.io/jenkinsxio/builder-nodejs:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-nodejs:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/istio/expected/v1/ConfigMap/jenkins-x-pod-template-nodejs10x.yaml
+++ b/tests/test_data/istio/expected/v1/ConfigMap/jenkins-x-pod-template-nodejs10x.yaml
@@ -22,7 +22,7 @@ data:
         emptyDir: {}
       containers:
       - name: nodejs
-        image: gcr.io/jenkinsxio/builder-nodejs10x:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-nodejs10x:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/istio/expected/v1/ConfigMap/jenkins-x-pod-template-nodejs12x.yaml
+++ b/tests/test_data/istio/expected/v1/ConfigMap/jenkins-x-pod-template-nodejs12x.yaml
@@ -22,7 +22,7 @@ data:
         emptyDir: {}
       containers:
       - name: nodejs
-        image: gcr.io/jenkinsxio/builder-nodejs12x:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-nodejs12x:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/istio/expected/v1/ConfigMap/jenkins-x-pod-template-nodejs8x.yaml
+++ b/tests/test_data/istio/expected/v1/ConfigMap/jenkins-x-pod-template-nodejs8x.yaml
@@ -22,7 +22,7 @@ data:
         emptyDir: {}
       containers:
       - name: nodejs
-        image: gcr.io/jenkinsxio/builder-nodejs8x:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-nodejs8x:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/istio/expected/v1/ConfigMap/jenkins-x-pod-template-php5x.yaml
+++ b/tests/test_data/istio/expected/v1/ConfigMap/jenkins-x-pod-template-php5x.yaml
@@ -22,7 +22,7 @@ data:
         emptyDir: {}
       containers:
       - name: nodejs
-        image: gcr.io/jenkinsxio/builder-php5x:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-php5x:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/istio/expected/v1/ConfigMap/jenkins-x-pod-template-php7x.yaml
+++ b/tests/test_data/istio/expected/v1/ConfigMap/jenkins-x-pod-template-php7x.yaml
@@ -22,7 +22,7 @@ data:
         emptyDir: {}
       containers:
       - name: nodejs
-        image: gcr.io/jenkinsxio/builder-php7x:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-php7x:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/istio/expected/v1/ConfigMap/jenkins-x-pod-template-promote.yaml
+++ b/tests/test_data/istio/expected/v1/ConfigMap/jenkins-x-pod-template-promote.yaml
@@ -22,7 +22,7 @@ data:
         emptyDir: {}
       containers:
       - name: promote
-        image: gcr.io/jenkinsxio/builder-jx:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-jx:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/istio/expected/v1/ConfigMap/jenkins-x-pod-template-python.yaml
+++ b/tests/test_data/istio/expected/v1/ConfigMap/jenkins-x-pod-template-python.yaml
@@ -22,7 +22,7 @@ data:
         emptyDir: {}
       containers:
       - name: python
-        image: gcr.io/jenkinsxio/builder-python:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-python:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/istio/expected/v1/ConfigMap/jenkins-x-pod-template-python2.yaml
+++ b/tests/test_data/istio/expected/v1/ConfigMap/jenkins-x-pod-template-python2.yaml
@@ -22,7 +22,7 @@ data:
         emptyDir: {}
       containers:
       - name: python
-        image: gcr.io/jenkinsxio/builder-python2:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-python2:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/istio/expected/v1/ConfigMap/jenkins-x-pod-template-python37.yaml
+++ b/tests/test_data/istio/expected/v1/ConfigMap/jenkins-x-pod-template-python37.yaml
@@ -22,7 +22,7 @@ data:
         emptyDir: {}
       containers:
       - name: python
-        image: gcr.io/jenkinsxio/builder-python37:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-python37:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/istio/expected/v1/ConfigMap/jenkins-x-pod-template-ruby.yaml
+++ b/tests/test_data/istio/expected/v1/ConfigMap/jenkins-x-pod-template-ruby.yaml
@@ -22,7 +22,7 @@ data:
         emptyDir: {}
       containers:
       - name: ruby
-        image: gcr.io/jenkinsxio/builder-ruby:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-ruby:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/istio/expected/v1/ConfigMap/jenkins-x-pod-template-rust.yaml
+++ b/tests/test_data/istio/expected/v1/ConfigMap/jenkins-x-pod-template-rust.yaml
@@ -22,7 +22,7 @@ data:
         emptyDir: {}
       containers:
       - name: rust
-        image: gcr.io/jenkinsxio/builder-rust:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-rust:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/istio/expected/v1/ConfigMap/jenkins-x-pod-template-scala.yaml
+++ b/tests/test_data/istio/expected/v1/ConfigMap/jenkins-x-pod-template-scala.yaml
@@ -28,7 +28,7 @@ data:
           secretName: jenkins-release-gpg
       containers:
       - name: scala
-        image: gcr.io/jenkinsxio/builder-scala:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-scala:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/istio/expected/v1/ConfigMap/jenkins-x-pod-template-swift.yaml
+++ b/tests/test_data/istio/expected/v1/ConfigMap/jenkins-x-pod-template-swift.yaml
@@ -22,7 +22,7 @@ data:
         emptyDir: {}
       containers:
       - name: swift
-        image: gcr.io/jenkinsxio/builder-swift:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-swift:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/istio/expected/v1/ConfigMap/jenkins-x-pod-template-terraform.yaml
+++ b/tests/test_data/istio/expected/v1/ConfigMap/jenkins-x-pod-template-terraform.yaml
@@ -22,7 +22,7 @@ data:
         emptyDir: {}
       containers:
       - name: terraform
-        image: gcr.io/jenkinsxio/builder-terraform:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-terraform:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/no-envs/expected/v1/ConfigMap/jenkins-x-pod-template-aws-cdk.yaml
+++ b/tests/test_data/no-envs/expected/v1/ConfigMap/jenkins-x-pod-template-aws-cdk.yaml
@@ -28,7 +28,7 @@ data:
           secretName: jenkins-release-gpg
       containers:
       - name: aws-cdk
-        image: gcr.io/jenkinsxio/builder-maven-nodejs:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-maven-nodejs:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/no-envs/expected/v1/ConfigMap/jenkins-x-pod-template-dlang.yaml
+++ b/tests/test_data/no-envs/expected/v1/ConfigMap/jenkins-x-pod-template-dlang.yaml
@@ -22,7 +22,7 @@ data:
         emptyDir: {}
       containers:
       - name: dlang
-        image: gcr.io/jenkinsxio/builder-dlang:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-dlang:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/no-envs/expected/v1/ConfigMap/jenkins-x-pod-template-gradle.yaml
+++ b/tests/test_data/no-envs/expected/v1/ConfigMap/jenkins-x-pod-template-gradle.yaml
@@ -25,7 +25,7 @@ data:
           secretName: jenkins-release-gpg
       containers:
       - name: gradle
-        image: gcr.io/jenkinsxio/builder-gradle:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-gradle:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/no-envs/expected/v1/ConfigMap/jenkins-x-pod-template-jx-base.yaml
+++ b/tests/test_data/no-envs/expected/v1/ConfigMap/jenkins-x-pod-template-jx-base.yaml
@@ -22,7 +22,7 @@ data:
         emptyDir: {}
       containers:
       - name: jx-base
-        image: gcr.io/jenkinsxio/builder-jx:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-jx:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/no-envs/expected/v1/ConfigMap/jenkins-x-pod-template-machine-learning-gpu.yaml
+++ b/tests/test_data/no-envs/expected/v1/ConfigMap/jenkins-x-pod-template-machine-learning-gpu.yaml
@@ -22,7 +22,7 @@ data:
         emptyDir: {}
       containers:
       - name: machine-learning
-        image: gcr.io/jenkinsxio/builder-machine-learning-gpu:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-machine-learning-gpu:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/no-envs/expected/v1/ConfigMap/jenkins-x-pod-template-machine-learning.yaml
+++ b/tests/test_data/no-envs/expected/v1/ConfigMap/jenkins-x-pod-template-machine-learning.yaml
@@ -22,7 +22,7 @@ data:
         emptyDir: {}
       containers:
       - name: machine-learning
-        image: gcr.io/jenkinsxio/builder-machine-learning:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-machine-learning:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/no-envs/expected/v1/ConfigMap/jenkins-x-pod-template-maven-graalvm.yaml
+++ b/tests/test_data/no-envs/expected/v1/ConfigMap/jenkins-x-pod-template-maven-graalvm.yaml
@@ -28,7 +28,7 @@ data:
           secretName: jenkins-release-gpg
       containers:
       - name: maven
-        image: gcr.io/jenkinsxio/builder-maven-graalvm:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-maven-graalvm:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/no-envs/expected/v1/ConfigMap/jenkins-x-pod-template-maven-java11.yaml
+++ b/tests/test_data/no-envs/expected/v1/ConfigMap/jenkins-x-pod-template-maven-java11.yaml
@@ -28,7 +28,7 @@ data:
           secretName: jenkins-release-gpg
       containers:
       - name: maven
-        image: gcr.io/jenkinsxio/builder-maven-java11:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-maven-java11:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/no-envs/expected/v1/ConfigMap/jenkins-x-pod-template-maven-nodejs.yaml
+++ b/tests/test_data/no-envs/expected/v1/ConfigMap/jenkins-x-pod-template-maven-nodejs.yaml
@@ -28,7 +28,7 @@ data:
           secretName: jenkins-release-gpg
       containers:
       - name: mavennodejs
-        image: gcr.io/jenkinsxio/builder-maven-nodejs:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-maven-nodejs:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/no-envs/expected/v1/ConfigMap/jenkins-x-pod-template-maven.yaml
+++ b/tests/test_data/no-envs/expected/v1/ConfigMap/jenkins-x-pod-template-maven.yaml
@@ -28,7 +28,7 @@ data:
           secretName: jenkins-release-gpg
       containers:
       - name: maven
-        image: gcr.io/jenkinsxio/builder-maven:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-maven:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/no-envs/expected/v1/ConfigMap/jenkins-x-pod-template-newman.yaml
+++ b/tests/test_data/no-envs/expected/v1/ConfigMap/jenkins-x-pod-template-newman.yaml
@@ -22,7 +22,7 @@ data:
         emptyDir: {}
       containers:
       - name: newman
-        image: gcr.io/jenkinsxio/builder-newman:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-newman:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/no-envs/expected/v1/ConfigMap/jenkins-x-pod-template-nodejs.yaml
+++ b/tests/test_data/no-envs/expected/v1/ConfigMap/jenkins-x-pod-template-nodejs.yaml
@@ -22,7 +22,7 @@ data:
         emptyDir: {}
       containers:
       - name: nodejs
-        image: gcr.io/jenkinsxio/builder-nodejs:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-nodejs:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/no-envs/expected/v1/ConfigMap/jenkins-x-pod-template-nodejs10x.yaml
+++ b/tests/test_data/no-envs/expected/v1/ConfigMap/jenkins-x-pod-template-nodejs10x.yaml
@@ -22,7 +22,7 @@ data:
         emptyDir: {}
       containers:
       - name: nodejs
-        image: gcr.io/jenkinsxio/builder-nodejs10x:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-nodejs10x:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/no-envs/expected/v1/ConfigMap/jenkins-x-pod-template-nodejs12x.yaml
+++ b/tests/test_data/no-envs/expected/v1/ConfigMap/jenkins-x-pod-template-nodejs12x.yaml
@@ -22,7 +22,7 @@ data:
         emptyDir: {}
       containers:
       - name: nodejs
-        image: gcr.io/jenkinsxio/builder-nodejs12x:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-nodejs12x:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/no-envs/expected/v1/ConfigMap/jenkins-x-pod-template-nodejs8x.yaml
+++ b/tests/test_data/no-envs/expected/v1/ConfigMap/jenkins-x-pod-template-nodejs8x.yaml
@@ -22,7 +22,7 @@ data:
         emptyDir: {}
       containers:
       - name: nodejs
-        image: gcr.io/jenkinsxio/builder-nodejs8x:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-nodejs8x:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/no-envs/expected/v1/ConfigMap/jenkins-x-pod-template-php5x.yaml
+++ b/tests/test_data/no-envs/expected/v1/ConfigMap/jenkins-x-pod-template-php5x.yaml
@@ -22,7 +22,7 @@ data:
         emptyDir: {}
       containers:
       - name: nodejs
-        image: gcr.io/jenkinsxio/builder-php5x:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-php5x:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/no-envs/expected/v1/ConfigMap/jenkins-x-pod-template-php7x.yaml
+++ b/tests/test_data/no-envs/expected/v1/ConfigMap/jenkins-x-pod-template-php7x.yaml
@@ -22,7 +22,7 @@ data:
         emptyDir: {}
       containers:
       - name: nodejs
-        image: gcr.io/jenkinsxio/builder-php7x:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-php7x:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/no-envs/expected/v1/ConfigMap/jenkins-x-pod-template-promote.yaml
+++ b/tests/test_data/no-envs/expected/v1/ConfigMap/jenkins-x-pod-template-promote.yaml
@@ -22,7 +22,7 @@ data:
         emptyDir: {}
       containers:
       - name: promote
-        image: gcr.io/jenkinsxio/builder-jx:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-jx:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/no-envs/expected/v1/ConfigMap/jenkins-x-pod-template-python.yaml
+++ b/tests/test_data/no-envs/expected/v1/ConfigMap/jenkins-x-pod-template-python.yaml
@@ -22,7 +22,7 @@ data:
         emptyDir: {}
       containers:
       - name: python
-        image: gcr.io/jenkinsxio/builder-python:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-python:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/no-envs/expected/v1/ConfigMap/jenkins-x-pod-template-python2.yaml
+++ b/tests/test_data/no-envs/expected/v1/ConfigMap/jenkins-x-pod-template-python2.yaml
@@ -22,7 +22,7 @@ data:
         emptyDir: {}
       containers:
       - name: python
-        image: gcr.io/jenkinsxio/builder-python2:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-python2:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/no-envs/expected/v1/ConfigMap/jenkins-x-pod-template-python37.yaml
+++ b/tests/test_data/no-envs/expected/v1/ConfigMap/jenkins-x-pod-template-python37.yaml
@@ -22,7 +22,7 @@ data:
         emptyDir: {}
       containers:
       - name: python
-        image: gcr.io/jenkinsxio/builder-python37:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-python37:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/no-envs/expected/v1/ConfigMap/jenkins-x-pod-template-ruby.yaml
+++ b/tests/test_data/no-envs/expected/v1/ConfigMap/jenkins-x-pod-template-ruby.yaml
@@ -22,7 +22,7 @@ data:
         emptyDir: {}
       containers:
       - name: ruby
-        image: gcr.io/jenkinsxio/builder-ruby:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-ruby:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/no-envs/expected/v1/ConfigMap/jenkins-x-pod-template-rust.yaml
+++ b/tests/test_data/no-envs/expected/v1/ConfigMap/jenkins-x-pod-template-rust.yaml
@@ -22,7 +22,7 @@ data:
         emptyDir: {}
       containers:
       - name: rust
-        image: gcr.io/jenkinsxio/builder-rust:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-rust:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/no-envs/expected/v1/ConfigMap/jenkins-x-pod-template-scala.yaml
+++ b/tests/test_data/no-envs/expected/v1/ConfigMap/jenkins-x-pod-template-scala.yaml
@@ -28,7 +28,7 @@ data:
           secretName: jenkins-release-gpg
       containers:
       - name: scala
-        image: gcr.io/jenkinsxio/builder-scala:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-scala:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/no-envs/expected/v1/ConfigMap/jenkins-x-pod-template-swift.yaml
+++ b/tests/test_data/no-envs/expected/v1/ConfigMap/jenkins-x-pod-template-swift.yaml
@@ -22,7 +22,7 @@ data:
         emptyDir: {}
       containers:
       - name: swift
-        image: gcr.io/jenkinsxio/builder-swift:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-swift:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/no-envs/expected/v1/ConfigMap/jenkins-x-pod-template-terraform.yaml
+++ b/tests/test_data/no-envs/expected/v1/ConfigMap/jenkins-x-pod-template-terraform.yaml
@@ -22,7 +22,7 @@ data:
         emptyDir: {}
       containers:
       - name: terraform
-        image: gcr.io/jenkinsxio/builder-terraform:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-terraform:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/remote-env/expected/v1/ConfigMap/jenkins-x-pod-template-aws-cdk.yaml
+++ b/tests/test_data/remote-env/expected/v1/ConfigMap/jenkins-x-pod-template-aws-cdk.yaml
@@ -28,7 +28,7 @@ data:
           secretName: jenkins-release-gpg
       containers:
       - name: aws-cdk
-        image: gcr.io/jenkinsxio/builder-maven-nodejs:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-maven-nodejs:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/remote-env/expected/v1/ConfigMap/jenkins-x-pod-template-dlang.yaml
+++ b/tests/test_data/remote-env/expected/v1/ConfigMap/jenkins-x-pod-template-dlang.yaml
@@ -22,7 +22,7 @@ data:
         emptyDir: {}
       containers:
       - name: dlang
-        image: gcr.io/jenkinsxio/builder-dlang:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-dlang:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/remote-env/expected/v1/ConfigMap/jenkins-x-pod-template-gradle.yaml
+++ b/tests/test_data/remote-env/expected/v1/ConfigMap/jenkins-x-pod-template-gradle.yaml
@@ -25,7 +25,7 @@ data:
           secretName: jenkins-release-gpg
       containers:
       - name: gradle
-        image: gcr.io/jenkinsxio/builder-gradle:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-gradle:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/remote-env/expected/v1/ConfigMap/jenkins-x-pod-template-jx-base.yaml
+++ b/tests/test_data/remote-env/expected/v1/ConfigMap/jenkins-x-pod-template-jx-base.yaml
@@ -22,7 +22,7 @@ data:
         emptyDir: {}
       containers:
       - name: jx-base
-        image: gcr.io/jenkinsxio/builder-jx:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-jx:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/remote-env/expected/v1/ConfigMap/jenkins-x-pod-template-machine-learning-gpu.yaml
+++ b/tests/test_data/remote-env/expected/v1/ConfigMap/jenkins-x-pod-template-machine-learning-gpu.yaml
@@ -22,7 +22,7 @@ data:
         emptyDir: {}
       containers:
       - name: machine-learning
-        image: gcr.io/jenkinsxio/builder-machine-learning-gpu:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-machine-learning-gpu:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/remote-env/expected/v1/ConfigMap/jenkins-x-pod-template-machine-learning.yaml
+++ b/tests/test_data/remote-env/expected/v1/ConfigMap/jenkins-x-pod-template-machine-learning.yaml
@@ -22,7 +22,7 @@ data:
         emptyDir: {}
       containers:
       - name: machine-learning
-        image: gcr.io/jenkinsxio/builder-machine-learning:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-machine-learning:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/remote-env/expected/v1/ConfigMap/jenkins-x-pod-template-maven-graalvm.yaml
+++ b/tests/test_data/remote-env/expected/v1/ConfigMap/jenkins-x-pod-template-maven-graalvm.yaml
@@ -28,7 +28,7 @@ data:
           secretName: jenkins-release-gpg
       containers:
       - name: maven
-        image: gcr.io/jenkinsxio/builder-maven-graalvm:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-maven-graalvm:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/remote-env/expected/v1/ConfigMap/jenkins-x-pod-template-maven-java11.yaml
+++ b/tests/test_data/remote-env/expected/v1/ConfigMap/jenkins-x-pod-template-maven-java11.yaml
@@ -28,7 +28,7 @@ data:
           secretName: jenkins-release-gpg
       containers:
       - name: maven
-        image: gcr.io/jenkinsxio/builder-maven-java11:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-maven-java11:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/remote-env/expected/v1/ConfigMap/jenkins-x-pod-template-maven-nodejs.yaml
+++ b/tests/test_data/remote-env/expected/v1/ConfigMap/jenkins-x-pod-template-maven-nodejs.yaml
@@ -28,7 +28,7 @@ data:
           secretName: jenkins-release-gpg
       containers:
       - name: mavennodejs
-        image: gcr.io/jenkinsxio/builder-maven-nodejs:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-maven-nodejs:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/remote-env/expected/v1/ConfigMap/jenkins-x-pod-template-maven.yaml
+++ b/tests/test_data/remote-env/expected/v1/ConfigMap/jenkins-x-pod-template-maven.yaml
@@ -28,7 +28,7 @@ data:
           secretName: jenkins-release-gpg
       containers:
       - name: maven
-        image: gcr.io/jenkinsxio/builder-maven:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-maven:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/remote-env/expected/v1/ConfigMap/jenkins-x-pod-template-newman.yaml
+++ b/tests/test_data/remote-env/expected/v1/ConfigMap/jenkins-x-pod-template-newman.yaml
@@ -22,7 +22,7 @@ data:
         emptyDir: {}
       containers:
       - name: newman
-        image: gcr.io/jenkinsxio/builder-newman:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-newman:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/remote-env/expected/v1/ConfigMap/jenkins-x-pod-template-nodejs.yaml
+++ b/tests/test_data/remote-env/expected/v1/ConfigMap/jenkins-x-pod-template-nodejs.yaml
@@ -22,7 +22,7 @@ data:
         emptyDir: {}
       containers:
       - name: nodejs
-        image: gcr.io/jenkinsxio/builder-nodejs:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-nodejs:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/remote-env/expected/v1/ConfigMap/jenkins-x-pod-template-nodejs10x.yaml
+++ b/tests/test_data/remote-env/expected/v1/ConfigMap/jenkins-x-pod-template-nodejs10x.yaml
@@ -22,7 +22,7 @@ data:
         emptyDir: {}
       containers:
       - name: nodejs
-        image: gcr.io/jenkinsxio/builder-nodejs10x:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-nodejs10x:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/remote-env/expected/v1/ConfigMap/jenkins-x-pod-template-nodejs12x.yaml
+++ b/tests/test_data/remote-env/expected/v1/ConfigMap/jenkins-x-pod-template-nodejs12x.yaml
@@ -22,7 +22,7 @@ data:
         emptyDir: {}
       containers:
       - name: nodejs
-        image: gcr.io/jenkinsxio/builder-nodejs12x:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-nodejs12x:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/remote-env/expected/v1/ConfigMap/jenkins-x-pod-template-nodejs8x.yaml
+++ b/tests/test_data/remote-env/expected/v1/ConfigMap/jenkins-x-pod-template-nodejs8x.yaml
@@ -22,7 +22,7 @@ data:
         emptyDir: {}
       containers:
       - name: nodejs
-        image: gcr.io/jenkinsxio/builder-nodejs8x:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-nodejs8x:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/remote-env/expected/v1/ConfigMap/jenkins-x-pod-template-php5x.yaml
+++ b/tests/test_data/remote-env/expected/v1/ConfigMap/jenkins-x-pod-template-php5x.yaml
@@ -22,7 +22,7 @@ data:
         emptyDir: {}
       containers:
       - name: nodejs
-        image: gcr.io/jenkinsxio/builder-php5x:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-php5x:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/remote-env/expected/v1/ConfigMap/jenkins-x-pod-template-php7x.yaml
+++ b/tests/test_data/remote-env/expected/v1/ConfigMap/jenkins-x-pod-template-php7x.yaml
@@ -22,7 +22,7 @@ data:
         emptyDir: {}
       containers:
       - name: nodejs
-        image: gcr.io/jenkinsxio/builder-php7x:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-php7x:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/remote-env/expected/v1/ConfigMap/jenkins-x-pod-template-promote.yaml
+++ b/tests/test_data/remote-env/expected/v1/ConfigMap/jenkins-x-pod-template-promote.yaml
@@ -22,7 +22,7 @@ data:
         emptyDir: {}
       containers:
       - name: promote
-        image: gcr.io/jenkinsxio/builder-jx:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-jx:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/remote-env/expected/v1/ConfigMap/jenkins-x-pod-template-python.yaml
+++ b/tests/test_data/remote-env/expected/v1/ConfigMap/jenkins-x-pod-template-python.yaml
@@ -22,7 +22,7 @@ data:
         emptyDir: {}
       containers:
       - name: python
-        image: gcr.io/jenkinsxio/builder-python:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-python:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/remote-env/expected/v1/ConfigMap/jenkins-x-pod-template-python2.yaml
+++ b/tests/test_data/remote-env/expected/v1/ConfigMap/jenkins-x-pod-template-python2.yaml
@@ -22,7 +22,7 @@ data:
         emptyDir: {}
       containers:
       - name: python
-        image: gcr.io/jenkinsxio/builder-python2:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-python2:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/remote-env/expected/v1/ConfigMap/jenkins-x-pod-template-python37.yaml
+++ b/tests/test_data/remote-env/expected/v1/ConfigMap/jenkins-x-pod-template-python37.yaml
@@ -22,7 +22,7 @@ data:
         emptyDir: {}
       containers:
       - name: python
-        image: gcr.io/jenkinsxio/builder-python37:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-python37:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/remote-env/expected/v1/ConfigMap/jenkins-x-pod-template-ruby.yaml
+++ b/tests/test_data/remote-env/expected/v1/ConfigMap/jenkins-x-pod-template-ruby.yaml
@@ -22,7 +22,7 @@ data:
         emptyDir: {}
       containers:
       - name: ruby
-        image: gcr.io/jenkinsxio/builder-ruby:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-ruby:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/remote-env/expected/v1/ConfigMap/jenkins-x-pod-template-rust.yaml
+++ b/tests/test_data/remote-env/expected/v1/ConfigMap/jenkins-x-pod-template-rust.yaml
@@ -22,7 +22,7 @@ data:
         emptyDir: {}
       containers:
       - name: rust
-        image: gcr.io/jenkinsxio/builder-rust:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-rust:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/remote-env/expected/v1/ConfigMap/jenkins-x-pod-template-scala.yaml
+++ b/tests/test_data/remote-env/expected/v1/ConfigMap/jenkins-x-pod-template-scala.yaml
@@ -28,7 +28,7 @@ data:
           secretName: jenkins-release-gpg
       containers:
       - name: scala
-        image: gcr.io/jenkinsxio/builder-scala:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-scala:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/remote-env/expected/v1/ConfigMap/jenkins-x-pod-template-swift.yaml
+++ b/tests/test_data/remote-env/expected/v1/ConfigMap/jenkins-x-pod-template-swift.yaml
@@ -22,7 +22,7 @@ data:
         emptyDir: {}
       containers:
       - name: swift
-        image: gcr.io/jenkinsxio/builder-swift:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-swift:2.0.1245-582
         args:
         - cat
         command:

--- a/tests/test_data/remote-env/expected/v1/ConfigMap/jenkins-x-pod-template-terraform.yaml
+++ b/tests/test_data/remote-env/expected/v1/ConfigMap/jenkins-x-pod-template-terraform.yaml
@@ -22,7 +22,7 @@ data:
         emptyDir: {}
       containers:
       - name: terraform
-        image: gcr.io/jenkinsxio/builder-terraform:2.0.1244-581
+        image: gcr.io/jenkinsxio/builder-terraform:2.0.1245-582
         args:
         - cat
         command:


### PR DESCRIPTION
to avoid breaking jx command line tools which detect Ingress resources - e.g. jx import detects the hook URL