### PR TITLE
fix: avoid namespace in the path

### DIFF
--- a/jxboot-helmfile-resources/templates/700-bucketrepo-ing.yaml
+++ b/jxboot-helmfile-resources/templates/700-bucketrepo-ing.yaml
@@ -19,7 +19,7 @@ spec:
           serviceName: bucketrepo
           servicePort: 80
 {{- if eq "NodePort" .Values.jxRequirements.ingress.serviceType }}
-        path: "/{{ .Release.Namespace }}/bucketrepo"
+        path: "/bucketrepo"
 {{- else if .Values.jxRequirements.ingress.domain }}
     host: bucketrepo{{ .Values.jxRequirements.ingress.namespaceSubDomain }}{{ .Values.jxRequirements.ingress.domain }}
 {{- end }}

--- a/jxboot-helmfile-resources/templates/700-chartmuseum-ing.yaml
+++ b/jxboot-helmfile-resources/templates/700-chartmuseum-ing.yaml
@@ -19,7 +19,7 @@ spec:
           serviceName: jenkins-x-chartmuseum
           servicePort: 8080
 {{- if eq "NodePort" .Values.jxRequirements.ingress.serviceType }}
-        path: "/{{ .Release.Namespace }}/chartmuseum"
+        path: "/chartmuseum"
 {{- else if .Values.jxRequirements.ingress.domain }}
     host: chartmuseum{{ .Values.jxRequirements.ingress.namespaceSubDomain }}{{ .Values.jxRequirements.ingress.domain }}
 {{- end }}

--- a/jxboot-helmfile-resources/templates/700-docker-ing.yaml
+++ b/jxboot-helmfile-resources/templates/700-docker-ing.yaml
@@ -21,7 +21,7 @@ spec:
           serviceName: jenkins-x-docker-registry
           servicePort: 5000
 {{- if eq "NodePort" .Values.jxRequirements.ingress.serviceType }}
-        path: "/{{ .Release.Namespace }}/docker-registry"
+        path: "/docker-registry"
 {{- else if .Values.jxRequirements.ingress.domain }}
     host: docker-registry{{ .Values.jxRequirements.ingress.namespaceSubDomain }}{{ .Values.jxRequirements.ingress.domain }}
 {{- end }}

--- a/jxboot-helmfile-resources/templates/700-hook-ing.yaml
+++ b/jxboot-helmfile-resources/templates/700-hook-ing.yaml
@@ -19,7 +19,7 @@ spec:
           serviceName: hook
           servicePort: 80
 {{- if eq "NodePort" .Values.jxRequirements.ingress.serviceType }}
-        path: "/{{ .Release.Namespace }}/hook"
+        path: "/hook"
 {{- else if .Values.jxRequirements.ingress.domain }}
     host: hook{{ .Values.jxRequirements.ingress.namespaceSubDomain }}{{ .Values.jxRequirements.ingress.domain }}
 {{- end }}

--- a/jxboot-helmfile-resources/templates/700-nexus-ing.yaml
+++ b/jxboot-helmfile-resources/templates/700-nexus-ing.yaml
@@ -19,7 +19,7 @@ spec:
           serviceName: nexus
           servicePort: 80
 {{- if eq "NodePort" .Values.jxRequirements.ingress.serviceType }}
-        path: "/{{ .Release.Namespace }}/nexus"
+        path: "/nexus"
 {{- else if .Values.jxRequirements.ingress.domain }}
     host: nexus{{ .Values.jxRequirements.ingress.namespaceSubDomain }}{{ .Values.jxRequirements.ingress.domain }}
 {{- end }}


### PR DESCRIPTION
when using NodePort as most of these services cannot handle a different path. At least there's usually only one of these services in the dev environment anyway