### PR TITLE
fix: avoid using blank default jxRequirements.ingress.tls.secretName

### DIFF
--- a/jxboot-helmfile-resources/templates/700-bucketrepo-ing.yaml
+++ b/jxboot-helmfile-resources/templates/700-bucketrepo-ing.yaml
@@ -27,7 +27,7 @@ spec:
   tls:
   - hosts:
     - bucketrepo{{ .Values.jxRequirements.ingress.namespaceSubDomain }}{{ .Values.jxRequirements.ingress.domain }}
-{{- if hasKey .Values.jxRequirements.ingress.tls "secretName" }}
+{{- if .Values.jxRequirements.ingress.tls.secretName }}
     secretName: "{{ .Values.jxRequirements.ingress.tls.secretName }}"
 {{- else if .Values.jxRequirements.ingress.tls.production }}
     secretName: "tls-{{ .Values.jxRequirements.ingress.domain | replace "." "-" }}-p"

--- a/jxboot-helmfile-resources/templates/700-chartmuseum-ing.yaml
+++ b/jxboot-helmfile-resources/templates/700-chartmuseum-ing.yaml
@@ -27,7 +27,7 @@ spec:
   tls:
   - hosts:
     - chartmuseum{{ .Values.jxRequirements.ingress.namespaceSubDomain }}{{ .Values.jxRequirements.ingress.domain }}
-{{- if hasKey .Values.jxRequirements.ingress.tls "secretName" }}
+{{- if .Values.jxRequirements.ingress.tls.secretName }}
     secretName: "{{ .Values.jxRequirements.ingress.tls.secretName }}"
 {{- else if .Values.jxRequirements.ingress.tls.production }}
     secretName: "tls-{{ .Values.jxRequirements.ingress.domain | replace "." "-" }}-p"

--- a/jxboot-helmfile-resources/templates/700-docker-ing.yaml
+++ b/jxboot-helmfile-resources/templates/700-docker-ing.yaml
@@ -29,7 +29,7 @@ spec:
   tls:
   - hosts:
     - docker-registry{{ .Values.jxRequirements.ingress.namespaceSubDomain }}{{ .Values.jxRequirements.ingress.domain }}
-{{- if hasKey .Values.jxRequirements.ingress.tls "secretName" }}
+{{- if .Values.jxRequirements.ingress.tls.secretName }}
     secretName: "{{ .Values.jxRequirements.ingress.tls.secretName }}"
 {{- else if .Values.jxRequirements.ingress.tls.production }}
     secretName: "tls-{{ .Values.jxRequirements.ingress.domain | replace "." "-" }}-p"

--- a/jxboot-helmfile-resources/templates/700-hook-ing.yaml
+++ b/jxboot-helmfile-resources/templates/700-hook-ing.yaml
@@ -27,7 +27,7 @@ spec:
   tls:
   - hosts:
     - hook{{ .Values.jxRequirements.ingress.namespaceSubDomain }}{{ .Values.jxRequirements.ingress.domain }}
-{{- if hasKey .Values.jxRequirements.ingress.tls "secretName" }}
+{{- if .Values.jxRequirements.ingress.tls.secretName }}
     secretName: "{{ .Values.jxRequirements.ingress.tls.secretName }}"
 {{- else if .Values.jxRequirements.ingress.tls.production }}
     secretName: "tls-{{ .Values.jxRequirements.ingress.domain | replace "." "-" }}-p"

--- a/jxboot-helmfile-resources/templates/700-nexus-ing.yaml
+++ b/jxboot-helmfile-resources/templates/700-nexus-ing.yaml
@@ -27,7 +27,7 @@ spec:
   tls:
   - hosts:
     - nexus{{ .Values.jxRequirements.ingress.namespaceSubDomain }}{{ .Values.jxRequirements.ingress.domain }}
-{{- if hasKey .Values.jxRequirements.ingress.tls "secretName" }}
+{{- if .Values.jxRequirements.ingress.tls.secretName }}
     secretName: "{{ .Values.jxRequirements.ingress.tls.secretName }}"
 {{- else if .Values.jxRequirements.ingress.tls.production }}
     secretName: "tls-{{ .Values.jxRequirements.ingress.domain | replace "." "-" }}-p"


### PR DESCRIPTION
it was always using the blank tls secretName. I suppose another possible fix was to use `{{- if .Values.jxRequirements.ingress.tls.secretName}}` instead of `{{- if hasKey .Values.jxRequirements.ingress.tls "secretName" }}`