### PR TITLE
fix: make hook ingress work with istio

### DIFF
--- a/jxboot-helmfile-resources/templates/700-hook-ing.yaml
+++ b/jxboot-helmfile-resources/templates/700-hook-ing.yaml
@@ -21,10 +21,8 @@ spec:
 {{- if eq "NodePort" .Values.jxRequirements.ingress.serviceType }}
         path: "/hook"
 {{- else if .Values.ingress.customHosts.hook }}
-        path: "/"
     host: {{ .Values.ingress.customHosts.hook }}
 {{- else if .Values.jxRequirements.ingress.domain }}
-        path: "/"
     host: {{ .Values.ingress.prefix.hook }}{{ .Values.jxRequirements.ingress.namespaceSubDomain }}{{ .Values.jxRequirements.ingress.domain }}
 {{- end }}
 {{- if .Values.jxRequirements.ingress.tls.enabled }}


### PR DESCRIPTION
Istio ingress treats path as exact match

kube 1.18+ introduces a new field pathType with values `Prefix` and `Exact`

removing the path has the same effect as `pathType: Prefix` without introducing the pathType field and works with both nginx and istio