### PR TITLE
feat: shared istio gateway with tls support

### DIFF
--- a/jxboot-helmfile-resources/templates/600-istio-gateway.yaml
+++ b/jxboot-helmfile-resources/templates/600-istio-gateway.yaml
@@ -1,0 +1,68 @@
+{{- if .Values.istio.enabled }}
+apiVersion: {{ .Values.istio.apiVersion }}
+kind: Gateway
+metadata:
+  name: jx-gateway
+spec:
+  selector:
+    app: istio-ingressgateway
+    istio: ingressgateway
+  servers:
+  - hosts:
+{{- if (eq "bucketrepo" .Values.jxRequirements.repository) }}
+    - bucketrepo{{ .Values.jxRequirements.ingress.namespaceSubDomain }}{{ .Values.jxRequirements.ingress.domain }}
+{{- end }}
+{{- if (eq "nexus" .Values.jxRequirements.repository) }}
+    - chartmuseum{{ .Values.jxRequirements.ingress.namespaceSubDomain }}{{ .Values.jxRequirements.ingress.domain }}
+    - nexus{{ .Values.jxRequirements.ingress.namespaceSubDomain }}{{ .Values.jxRequirements.ingress.domain }}
+{{- end }}
+{{- if (index .Values "docker-registry" "enabled") }}
+    - docker-registry{{ .Values.jxRequirements.ingress.namespaceSubDomain }}{{ .Values.jxRequirements.ingress.domain }}
+{{- end }}
+{{- if (or (eq "lighthouse" .Values.jxRequirements.webhook) (eq "prow" .Values.jxRequirements.webhook)) }}
+    - hook{{ .Values.jxRequirements.ingress.namespaceSubDomain }}{{ .Values.jxRequirements.ingress.domain }}
+{{- end }}
+{{- if .Values.istio.gateway.additionalHosts }}
+  {{- range .Values.istio.gateway.additionalHosts }}
+    - {{.}}
+  {{- end }}
+{{- end}}
+    port:
+      number: 80
+      name: http
+      protocol: HTTP
+{{- if .Values.jxRequirements.ingress.tls.enabled }}
+    tls:
+      httpsRedirect: true
+  - hosts:
+{{- if (eq "bucketrepo" .Values.jxRequirements.repository) }}
+    - bucketrepo{{ .Values.jxRequirements.ingress.namespaceSubDomain }}{{ .Values.jxRequirements.ingress.domain }}
+{{- end }}
+{{- if (eq "nexus" .Values.jxRequirements.repository) }}
+    - chartmuseum{{ .Values.jxRequirements.ingress.namespaceSubDomain }}{{ .Values.jxRequirements.ingress.domain }}
+    - nexus{{ .Values.jxRequirements.ingress.namespaceSubDomain }}{{ .Values.jxRequirements.ingress.domain }}
+{{- end }}
+{{- if (index .Values "docker-registry" "enabled") }}
+    - docker-registry{{ .Values.jxRequirements.ingress.namespaceSubDomain }}{{ .Values.jxRequirements.ingress.domain }}
+{{- end }}
+{{- if (or (eq "lighthouse" .Values.jxRequirements.webhook) (eq "prow" .Values.jxRequirements.webhook)) }}
+    - hook{{ .Values.jxRequirements.ingress.namespaceSubDomain }}{{ .Values.jxRequirements.ingress.domain }}
+{{- end }}
+{{- if .Values.istio.gateway.additionalHosts }}
+  {{- range .Values.istio.gateway.additionalHosts }}
+    - {{.}}
+  {{- end }}
+{{- end}}
+    port:
+      number: 443
+      name: https
+      protocol: HTTPS
+    tls:
+{{- if .Values.istio.gateway.tlsCertSecret }}
+      credentialName: {{ .Values.istio.gateway.tlsCertSecret }}
+{{- else }}
+      credentialName: tls-{{ .Values.jxRequirements.ingress.domain | replace "." "-" }}-p
+{{- end }}
+      mode: SIMPLE
+{{- end }}
+{{- end }}

--- a/jxboot-helmfile-resources/templates/700-bucketrepo-ing.yaml
+++ b/jxboot-helmfile-resources/templates/700-bucketrepo-ing.yaml
@@ -1,4 +1,4 @@
-{{- if (eq "bucketrepo" .Values.jxRequirements.repository) }}
+{{- if and (eq "bucketrepo" .Values.jxRequirements.repository) (not .Values.istio.enabled) }}
 apiVersion: {{ .Values.ingress.apiVersion | default "networking.k8s.io/v1beta1" }}
 kind: Ingress
 metadata:

--- a/jxboot-helmfile-resources/templates/700-bucketrepo-vs.yaml
+++ b/jxboot-helmfile-resources/templates/700-bucketrepo-vs.yaml
@@ -1,27 +1,11 @@
-{{- if and (eq "bucketrepo" .Values.jxRequirements.repository) (eq "istio" .Values.jxRequirements.ingress.kind) }}
-apiVersion: networking.istio.io/v1beta1
-kind: Gateway
-metadata:
-  name: bucketrepo
-spec:
-  selector:
-    istio: ingressgateway
-  servers:
-  - hosts:
-    - bucketrepo{{ .Values.jxRequirements.ingress.namespaceSubDomain }}{{ .Values.jxRequirements.ingress.domain }}
-    port:
-      name: http
-      number: 80
-      protocol: HTTP
----
-
-apiVersion: networking.istio.io/v1beta1
+{{- if and (eq "bucketrepo" .Values.jxRequirements.repository) .Values.istio.enabled }}
+apiVersion: {{ .Values.istio.apiVersion }}
 kind: VirtualService
 metadata:
   name: bucketrepo
 spec:
   gateways:
-  - bucketrepo
+  - jx-gateway
   hosts:
     - bucketrepo{{ .Values.jxRequirements.ingress.namespaceSubDomain }}{{ .Values.jxRequirements.ingress.domain }}
   http:

--- a/jxboot-helmfile-resources/templates/700-chartmuseum-ing.yaml
+++ b/jxboot-helmfile-resources/templates/700-chartmuseum-ing.yaml
@@ -1,4 +1,4 @@
-{{- if (eq "nexus" .Values.jxRequirements.repository) }}
+{{- if and (eq "nexus" .Values.jxRequirements.repository) (not .Values.istio.enabled) }}
 apiVersion: {{ .Values.ingress.apiVersion | default "networking.k8s.io/v1beta1" }}
 kind: Ingress
 metadata:

--- a/jxboot-helmfile-resources/templates/700-chartmuseum-vs.yaml
+++ b/jxboot-helmfile-resources/templates/700-chartmuseum-vs.yaml
@@ -1,27 +1,11 @@
-{{- if and (eq "nexus" .Values.jxRequirements.repository) (eq "istio" .Values.jxRequirements.ingress.kind) }}
-apiVersion: networking.istio.io/v1beta1
-kind: Gateway
-metadata:
-  name: chartmuseum
-spec:
-  selector:
-    istio: ingressgateway
-  servers:
-  - hosts:
-    - chartmuseum{{ .Values.jxRequirements.ingress.namespaceSubDomain }}{{ .Values.jxRequirements.ingress.domain }}
-    port:
-      name: http
-      number: 80
-      protocol: HTTP
----
-
-apiVersion: networking.istio.io/v1beta1
+{{- if and (eq "nexus" .Values.jxRequirements.repository) .Values.istio.enabled }}
+apiVersion: {{ .Values.istio.apiVersion }}
 kind: VirtualService
 metadata:
   name: chartmuseum
 spec:
   gateways:
-  - chartmuseum
+  - jx-gateway
   hosts:
     - chartmuseum{{ .Values.jxRequirements.ingress.namespaceSubDomain }}{{ .Values.jxRequirements.ingress.domain }}
   http:

--- a/jxboot-helmfile-resources/templates/700-docker-ing.yaml
+++ b/jxboot-helmfile-resources/templates/700-docker-ing.yaml
@@ -1,4 +1,4 @@
-{{- if (index .Values "docker-registry" "enabled")  }}
+{{- if and (index .Values "docker-registry" "enabled") (not .Values.istio.enabled) }}
 apiVersion: {{ .Values.ingress.apiVersion | default "networking.k8s.io/v1beta1" }}
 kind: Ingress
 metadata:

--- a/jxboot-helmfile-resources/templates/700-docker-vs.yaml
+++ b/jxboot-helmfile-resources/templates/700-docker-vs.yaml
@@ -1,27 +1,11 @@
-{{- if and (index .Values "docker-registry" "enabled") (eq "istio" .Values.jxRequirements.ingress.kind) }}
-apiVersion: networking.istio.io/v1beta1
-kind: Gateway
-metadata:
-  name: docker-registry
-spec:
-  selector:
-    istio: ingressgateway
-  servers:
-  - hosts:
-    - docker-registry{{ .Values.jxRequirements.ingress.namespaceSubDomain }}{{ .Values.jxRequirements.ingress.domain }}
-    port:
-      name: http
-      number: 80
-      protocol: HTTP
----
-
-apiVersion: networking.istio.io/v1beta1
+{{- if and (index .Values "docker-registry" "enabled") .Values.istio.enabled }}
+apiVersion: {{ .Values.istio.apiVersion }}
 kind: VirtualService
 metadata:
   name: docker-registry
 spec:
   gateways:
-  - docker-registry
+  - jx-gateway
   hosts:
     - docker-registry{{ .Values.jxRequirements.ingress.namespaceSubDomain }}{{ .Values.jxRequirements.ingress.domain }}
   http:

--- a/jxboot-helmfile-resources/templates/700-hook-ing.yaml
+++ b/jxboot-helmfile-resources/templates/700-hook-ing.yaml
@@ -1,4 +1,4 @@
-{{- if or (eq "lighthouse" .Values.jxRequirements.webhook) (eq "prow" .Values.jxRequirements.webhook) }}
+{{- if and (or (eq "lighthouse" .Values.jxRequirements.webhook) (eq "prow" .Values.jxRequirements.webhook)) (not .Values.istio.enabled) }}
 apiVersion: {{ .Values.ingress.apiVersion | default "networking.k8s.io/v1beta1" }}
 kind: Ingress
 metadata:

--- a/jxboot-helmfile-resources/templates/700-hook-vs.yaml
+++ b/jxboot-helmfile-resources/templates/700-hook-vs.yaml
@@ -1,27 +1,11 @@
-{{- if and (or (eq "lighthouse" .Values.jxRequirements.webhook) (eq "prow" .Values.jxRequirements.webhook)) (eq "istio" .Values.jxRequirements.ingress.kind) }}
-apiVersion: networking.istio.io/v1beta1
-kind: Gateway
-metadata:
-  name: hook
-spec:
-  selector:
-    istio: ingressgateway
-  servers:
-  - hosts:
-    - hook{{ .Values.jxRequirements.ingress.namespaceSubDomain }}{{ .Values.jxRequirements.ingress.domain }}
-    port:
-      name: http
-      number: 80
-      protocol: HTTP
----
-
-apiVersion: networking.istio.io/v1beta1
+{{- if and (or (eq "lighthouse" .Values.jxRequirements.webhook) (eq "prow" .Values.jxRequirements.webhook)) .Values.istio.enabled }}
+apiVersion: {{ .Values.istio.apiVersion }}
 kind: VirtualService
 metadata:
   name: hook
 spec:
   gateways:
-  - hook
+  - jx-gateway
   hosts:
     - hook{{ .Values.jxRequirements.ingress.namespaceSubDomain }}{{ .Values.jxRequirements.ingress.domain }}
   http:

--- a/jxboot-helmfile-resources/templates/700-nexus-ing.yaml
+++ b/jxboot-helmfile-resources/templates/700-nexus-ing.yaml
@@ -1,4 +1,4 @@
-{{- if (eq "nexus" .Values.jxRequirements.repository) }}
+{{- if and (eq "nexus" .Values.jxRequirements.repository) (not .Values.istio.enabled) }}
 apiVersion: {{ .Values.ingress.apiVersion | default "networking.k8s.io/v1beta1" }}
 kind: Ingress
 metadata:

--- a/jxboot-helmfile-resources/templates/700-nexus-vs.yaml
+++ b/jxboot-helmfile-resources/templates/700-nexus-vs.yaml
@@ -1,27 +1,11 @@
-{{- if and (eq "nexus" .Values.jxRequirements.repository) (eq "istio" .Values.jxRequirements.ingress.kind) }}
-apiVersion: networking.istio.io/v1beta1
-kind: Gateway
-metadata:
-  name: nexus
-spec:
-  selector:
-    istio: ingressgateway
-  servers:
-  - hosts:
-    - nexus{{ .Values.jxRequirements.ingress.namespaceSubDomain }}{{ .Values.jxRequirements.ingress.domain }}
-    port:
-      name: http
-      number: 80
-      protocol: HTTP
----
-
-apiVersion: networking.istio.io/v1beta1
+{{- if and (eq "nexus" .Values.jxRequirements.repository) .Values.istio.enabled }}
+apiVersion: {{ .Values.istio.apiVersion }}
 kind: VirtualService
 metadata:
   name: nexus
 spec:
   gateways:
-  - nexus
+  - jx-gateway
   hosts:
     - nexus{{ .Values.jxRequirements.ingress.namespaceSubDomain }}{{ .Values.jxRequirements.ingress.domain }}
   http:

--- a/jxboot-helmfile-resources/values.yaml
+++ b/jxboot-helmfile-resources/values.yaml
@@ -330,3 +330,9 @@ jxRequirements:
 npm:
   secret:
     enabled: false
+
+istio:
+  enabled: false
+  apiVersion: networking.istio.io/v1beta1
+  gateway:
+    additionalHosts: []


### PR DESCRIPTION
Signed-off-by: Patrick Lee Scott <pat@patscott.io>

When using the same TLS cert you need to use one gateway, not a separate gateway for each virtual service.
https://istio.io/latest/docs/ops/common-problems/network-issues/#404-errors-occur-when-multiple-gateways-configured-with-same-tls-certificate