### PR TITLE
fix: always quote pipelineVariables in jenkins-x-docker-registry secret

### DIFF
--- a/jxboot-helmfile-resources/templates/jenkins-x-docker-registry.yaml
+++ b/jxboot-helmfile-resources/templates/jenkins-x-docker-registry.yaml
@@ -17,6 +17,6 @@ data:
 
 {{- if .Values.jx.pipelineVariables }}
   {{- range $key, $value := .Values.jx.pipelineVariables }}
-  {{ $key }}: {{ $value }}
+  {{ $key }}: {{ $value | quote }}
   {{- end }}
 {{- end }}


### PR DESCRIPTION
jx boot fails if you have the following in `jx-global-values.yaml`

```
jx:
  pipelineVariables:
    SOME_VAR: "2"
```

Since the configmap is created with `2` instead of `"2"`

