### PR TITLE
fix: always use a path field in hook ingress

### DIFF
--- a/jxboot-helmfile-resources/templates/700-hook-ing.yaml
+++ b/jxboot-helmfile-resources/templates/700-hook-ing.yaml
@@ -18,9 +18,8 @@ spec:
       - backend:
           serviceName: hook
           servicePort: 80
-{{- if eq "NodePort" .Values.jxRequirements.ingress.serviceType }}
         path: "/hook"
-{{- else if .Values.ingress.customHosts.hook }}
+{{- if .Values.ingress.customHosts.hook }}
     host: {{ .Values.ingress.customHosts.hook }}
 {{- else if .Values.jxRequirements.ingress.domain }}
     host: {{ .Values.ingress.prefix.hook }}{{ .Values.jxRequirements.ingress.namespaceSubDomain }}{{ .Values.jxRequirements.ingress.domain }}


### PR DESCRIPTION
Since the hook halnder only works with a single uri, this will work in nginx as a prefix match and istio as an exact match

Some kuberenets dont like the missing `path` field https://app.slack.com/client/T09NY5SBT/C9LTHT2BB/thread/C9LTHT2BB-1610901756.076700