### PR TITLE
fix: add secret copy before running upgrade

### DIFF
--- a/charts/jxboot-helmfile-resources/templates/upgrade-cj.yaml
+++ b/charts/jxboot-helmfile-resources/templates/upgrade-cj.yaml
@@ -16,6 +16,23 @@ spec:
           labels:
             app: jenkins-x-updatebot
         spec:
+          initContainers:
+            - command:
+              - jx
+              - secret
+              - copy
+              - --name
+              - jx-boot-job-env-vars
+              - --ns
+              - jx-git-operator
+              - --to
+              - jx
+              name: copy-secret
+              image: "ghcr.io/jenkins-x/jx-boot:{{ .Values.versions.jx }}"
+              imagePullPolicy: Always
+              resources: {}
+              terminationMessagePath: /dev/termination-log
+              terminationMessagePolicy: File
           containers:
           - args:
             - env
@@ -28,7 +45,11 @@ spec:
             env:
             - name: HOME
               value: /home
-            image: gcr.io/jenkinsxio/jx-updatebot:{{ .Values.versions.updatebot }}
+            envFrom:
+            - secretRef:
+                name: jx-boot-job-env-vars
+                optional: true
+            image: "gcr.io/jenkinsxio/jx-updatebot:{{ .Values.versions.updatebot }}"
             imagePullPolicy: Always
             name: updatebot
             resources: {}

--- a/charts/jxboot-helmfile-resources/values.yaml
+++ b/charts/jxboot-helmfile-resources/values.yaml
@@ -127,10 +127,10 @@ gc:
 
 versions:
   # jx is the version of the jx-boot image
-  jx: 3.1.304
+  jx: 3.2.34
 
   # updatebot is the version of the jx-updatebot image
-  updatebot: 0.0.58
+  updatebot: 0.0.59
 
 # standard YAML files for jx boot:
 secrets:


### PR DESCRIPTION
so we can reuse any chart repository env vars when doing the upgrade

Signed-off-by: James Strachan <james.strachan@gmail.com>