### PR TITLE
fix: remove path when host can be set

### DIFF
--- a/charts/jxboot-helmfile-resources/templates/700-bucketrepo-ing.yaml
+++ b/charts/jxboot-helmfile-resources/templates/700-bucketrepo-ing.yaml
@@ -24,10 +24,8 @@ spec:
 {{- if eq "NodePort" .Values.jxRequirements.ingress.serviceType }}
         path: "/bucketrepo"
 {{- else if .Values.ingress.customHosts.bucketrepo }}
-        path: "/"
     host: {{ .Values.ingress.customHosts.bucketrepo }}
 {{- else if .Values.jxRequirements.ingress.domain }}
-        path: "/"
     host: {{ .Values.ingress.prefix.bucketrepo }}{{ .Values.jxRequirements.ingress.namespaceSubDomain }}{{ .Values.jxRequirements.ingress.domain }}
 {{- end }}
 {{- if .Values.jxRequirements.ingress.tls.enabled }}

--- a/charts/jxboot-helmfile-resources/templates/700-chartmuseum-ing.yaml
+++ b/charts/jxboot-helmfile-resources/templates/700-chartmuseum-ing.yaml
@@ -24,10 +24,8 @@ spec:
 {{- if eq "NodePort" .Values.jxRequirements.ingress.serviceType }}
         path: "/chartmuseum"
 {{- else if .Values.ingress.customHosts.chartmuseum }}
-        path: "/"
     host: {{ .Values.ingress.customHosts.chartmuseum }}
 {{- else if .Values.jxRequirements.ingress.domain }}
-        path: "/"
     host: {{ .Values.ingress.prefix.chartmuseum }}{{ .Values.jxRequirements.ingress.namespaceSubDomain }}{{ .Values.jxRequirements.ingress.domain }}
 {{- end }}
 {{- if .Values.jxRequirements.ingress.tls.enabled }}

--- a/charts/jxboot-helmfile-resources/templates/700-docker-ing.yaml
+++ b/charts/jxboot-helmfile-resources/templates/700-docker-ing.yaml
@@ -24,10 +24,8 @@ spec:
 {{- if eq "NodePort" .Values.jxRequirements.ingress.serviceType }}
         path: "/docker-registry"
 {{- else if .Values.ingress.customHosts.dockerRegistry }}
-        path: "/"
     host: {{ .Values.ingress.customHosts.dockerRegistry }}
 {{- else if .Values.jxRequirements.ingress.domain }}
-        path: "/"
     host: {{ .Values.ingress.prefix.dockerRegistry }}{{ .Values.jxRequirements.ingress.namespaceSubDomain }}{{ .Values.jxRequirements.ingress.domain }}
 {{- end }}
 {{- if .Values.jxRequirements.ingress.tls.enabled }}

--- a/charts/jxboot-helmfile-resources/templates/700-nexus-ing.yaml
+++ b/charts/jxboot-helmfile-resources/templates/700-nexus-ing.yaml
@@ -24,10 +24,8 @@ spec:
 {{- if eq "NodePort" .Values.jxRequirements.ingress.serviceType }}
         path: "/nexus"
 {{- else if .Values.ingress.customHosts.nexus }}
-        path: "/"
     host: {{ .Values.ingress.customHosts.nexus }}
 {{- else if .Values.jxRequirements.ingress.domain }}
-        path: "/"
     host: {{ .Values.ingress.prefix.nexus }}{{ .Values.jxRequirements.ingress.namespaceSubDomain }}{{ .Values.jxRequirements.ingress.domain }}
 {{- end }}
 {{- if .Values.jxRequirements.ingress.tls.enabled }}


### PR DESCRIPTION
Some ingress controllers like `aws-load-balancer-controller` needs the path to be `/*` to match what `/` does with `ingress-nginx`. Skipping the path attribute would be the easy way to make it work across ingress controllers.