### PR TITLE
fix: use clusterRole for gcjobs until jx gitops helmfile move doesn't change namespace

### DIFF
--- a/charts/jxboot-helmfile-resources/templates/jx-gcjobs-cr.yaml
+++ b/charts/jxboot-helmfile-resources/templates/jx-gcjobs-cr.yaml
@@ -1,8 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
+kind: ClusterRole
 metadata:
   name: gcjobs
-  namespace: {{ .Values.gc.jobs.role.ns | default "jx-git-operator" | quote }}
 rules:
   - apiGroups:
       - batch

--- a/charts/jxboot-helmfile-resources/templates/jx-gcjobs-crb.yaml
+++ b/charts/jxboot-helmfile-resources/templates/jx-gcjobs-crb.yaml
@@ -1,11 +1,10 @@
 apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
+kind: ClusterRoleBinding
 metadata:
   name: gcjobs
-  namespace: {{ .Values.gc.jobs.rb.ns | default "jx-git-operator" | quote }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: Role
+  kind: ClusterRole
   name: gcjobs
 subjects:
   - kind: ServiceAccount

--- a/charts/jxboot-helmfile-resources/templates/jx-gcjobs-cronjob.yaml
+++ b/charts/jxboot-helmfile-resources/templates/jx-gcjobs-cronjob.yaml
@@ -2,7 +2,6 @@ apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
   name: jx-gcjobs
-  namespace: {{ .Values.gc.jobs.cronjob.ns | default "jx-git-operator" | quote }}
 spec:
   concurrencyPolicy: Forbid
   failedJobsHistoryLimit: 1

--- a/charts/jxboot-helmfile-resources/templates/jx-gcjobs-sa.yaml
+++ b/charts/jxboot-helmfile-resources/templates/jx-gcjobs-sa.yaml
@@ -2,4 +2,3 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: jx-gcjobs
-  namespace: {{ .Values.gc.jobs.sa.ns | default "jx-git-operator" | quote }}

--- a/charts/jxboot-helmfile-resources/values.yaml
+++ b/charts/jxboot-helmfile-resources/values.yaml
@@ -133,14 +133,6 @@ gc:
   jobs:
     schedule: "0/30 */3 * * *"
     extraArgs: ["--namespace", "jx-git-operator"]
-    rb:
-      ns: "jx-git-operator"
-    sa:
-      ns: "jx-git-operator"
-    role:
-      ns: "jx-git-operator"
-    cronjob:
-      ns: "jx-git-operator"
 
 versions:
   # jx is the version of the jx-boot image


### PR DESCRIPTION
… change namespace