### PR TITLE
Support for running jobs in various namespaces

### DIFF
--- a/charts/jxboot-helmfile-resources/templates/jx-gcactivities-clusterrole.yaml
+++ b/charts/jxboot-helmfile-resources/templates/jx-gcactivities-clusterrole.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: gcactivities-cluster-scoped
+rules:
+  - apiGroups:
+      - jenkins.io
+    resources:
+      - pipelineactivities
+    verbs:
+      - list
+      - delete
+  - apiGroups:
+      - tekton.dev
+    resources:
+      - pipelineruns
+    verbs:
+      - get
+      - list
+      - watch
+      - delete
+  - apiGroups:
+    - lighthouse.jenkins.io
+    resources:
+      - lighthousejobs
+    verbs:
+      - list
+      - delete

--- a/charts/jxboot-helmfile-resources/templates/jx-gcactivities-crb.yaml
+++ b/charts/jxboot-helmfile-resources/templates/jx-gcactivities-crb.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: gcactivities
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: gcactivities-cluster-scoped
+subjects:
+  - kind: ServiceAccount
+    name: jx-gcactivities
+    namespace: {{ .Release.Namespace }}

--- a/charts/jxboot-helmfile-resources/templates/jx-gcactivities-cronjob.yaml
+++ b/charts/jxboot-helmfile-resources/templates/jx-gcactivities-cronjob.yaml
@@ -29,13 +29,14 @@ spec:
                 - gitops
                 - gc
                 - activities
+                - "--all-namespaces"
             {{- if .Values.gc.activities.extraArgs }}
               {{- range .Values.gc.activities.extraArgs }}
                 - {{.}}
               {{- end }}
             {{- end}}
               imagePullPolicy: IfNotPresent
-              image: "ghcr.io/jenkins-x/jx-boot:{{ .Values.versions.jx }}"
+              image: "{{ .Values.gc.activities.image }}:{{ .Values.versions.jx }}"
               env:
                 - name: JX_LOG_FORMAT
                   value: json

--- a/charts/jxboot-helmfile-resources/templates/jx-gcactivities-cronjob.yaml
+++ b/charts/jxboot-helmfile-resources/templates/jx-gcactivities-cronjob.yaml
@@ -36,7 +36,7 @@ spec:
               {{- end }}
             {{- end}}
               imagePullPolicy: IfNotPresent
-              image: "{{ .Values.gc.activities.image }}:{{ .Values.versions.jx }}"
+              image: "{{ .Values.gc.activities.image }}:{{ if .Values.gc.activities.tag }}{{ .Values.gc.activities.tag }}{{ else }}{{ .Values.versions.jx }}{{ end }}"
               env:
                 - name: JX_LOG_FORMAT
                   value: json

--- a/charts/jxboot-helmfile-resources/templates/jx-gcactivities-role.yaml
+++ b/charts/jxboot-helmfile-resources/templates/jx-gcactivities-role.yaml
@@ -6,13 +6,6 @@ rules:
   - apiGroups:
       - jenkins.io
     resources:
-      - pipelineactivities
-    verbs:
-      - list
-      - delete
-  - apiGroups:
-      - jenkins.io
-    resources:
       - environments
     verbs:
       - get
@@ -41,19 +34,3 @@ rules:
       - deployments
     verbs:
       - get
-  - apiGroups:
-      - tekton.dev
-    resources:
-      - pipelineruns
-    verbs:
-      - get
-      - list
-      - watch
-      - delete
-  - apiGroups:
-    - lighthouse.jenkins.io
-    resources:
-      - lighthousejobs
-    verbs:
-      - list
-      - delete

--- a/charts/jxboot-helmfile-resources/templates/jx-gcjobs-cronjob.yaml
+++ b/charts/jxboot-helmfile-resources/templates/jx-gcjobs-cronjob.yaml
@@ -36,7 +36,7 @@ spec:
               {{- end }}
             {{- end}}
               imagePullPolicy: IfNotPresent
-              image: "ghcr.io/jenkins-x/jx-boot:{{ .Values.versions.jx }}"
+              image: "{{ .Values.gc.pods.image }}:{{ if .Values.gc.pods.tag }}{{ .Values.gc.pods.tag }}{{ else }}{{ .Values.versions.jx }}{{ end }}"
               env:
                 - name: JX_LOG_FORMAT
                   value: json

--- a/charts/jxboot-helmfile-resources/templates/jx-gcjobs-rb.yaml
+++ b/charts/jxboot-helmfile-resources/templates/jx-gcjobs-rb.yaml
@@ -10,4 +10,4 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: jx-gcjobs
-    namespace: {{ .Release.Namespace }}
+    namespace: {{ .Values.gc.jobs.rb.ns | default "jx-git-operator" | quote }}

--- a/charts/jxboot-helmfile-resources/templates/jx-gcpods-clusterrole-ns.yaml
+++ b/charts/jxboot-helmfile-resources/templates/jx-gcpods-clusterrole-ns.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: gcpods-cluster-scoped-ns-listing
+rules:
+  # Only have to list namespaces to find those labelled namespaces, where pods should be deleted
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces
+    verbs:
+      - get
+      - list

--- a/charts/jxboot-helmfile-resources/templates/jx-gcpods-clusterrole.yaml
+++ b/charts/jxboot-helmfile-resources/templates/jx-gcpods-clusterrole.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
+kind: ClusterRole
 metadata:
-  name: gcpods
+  name: gcpods-per-namespace
 rules:
   - apiGroups:
       - jenkins.io

--- a/charts/jxboot-helmfile-resources/templates/jx-gcpods-crb-ns.yaml
+++ b/charts/jxboot-helmfile-resources/templates/jx-gcpods-crb-ns.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: gcpods-cluster-scoped-ns-listing
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: gcpods-cluster-scoped-ns-listing
+subjects:
+  - kind: ServiceAccount
+    name: jx-gcpods
+    namespace: {{ .Release.Namespace }}

--- a/charts/jxboot-helmfile-resources/templates/jx-gcpods-jx-git-operator-rb.yaml
+++ b/charts/jxboot-helmfile-resources/templates/jx-gcpods-jx-git-operator-rb.yaml
@@ -3,6 +3,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: gcpods
+  namespace: jx-git-operator
+  annotations:
+    gitops.jenkins-x.io/namespaceChange: keep-namespace-move-file
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/charts/jxboot-helmfile-resources/templates/jx-gcpods-other-ns-rb.yaml
+++ b/charts/jxboot-helmfile-resources/templates/jx-gcpods-other-ns-rb.yaml
@@ -3,7 +3,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: gcpods
+  name: gcpods-{{ . }}
   namespace: {{ . }}
   annotations:
     gitops.jenkins-x.io/namespaceChange: keep-namespace-move-file

--- a/charts/jxboot-helmfile-resources/templates/jx-gcpods-other-ns-rb.yaml
+++ b/charts/jxboot-helmfile-resources/templates/jx-gcpods-other-ns-rb.yaml
@@ -1,8 +1,12 @@
+{{- range .Values.jxJobsNamespaces }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: gcpods
+  namespace: {{ . }}
+  annotations:
+    gitops.jenkins-x.io/namespaceChange: keep-namespace-move-file
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -10,4 +14,5 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: jx-gcpods
-    namespace: {{ .Release.Namespace }}
+    namespace: {{ $.Release.Namespace }}
+{{- end }}

--- a/charts/jxboot-helmfile-resources/templates/jx-gcpods-rb.yaml
+++ b/charts/jxboot-helmfile-resources/templates/jx-gcpods-rb.yaml
@@ -1,12 +1,47 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: gcpods
+  namespace: jx-git-operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: gcpods-per-namespace
+subjects:
+  - kind: ServiceAccount
+    name: jx-gcpods
+    namespace: {{ .Release.Namespace }}
+
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: gcpods
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: gcpods
+  kind: ClusterRole
+  name: gcpods-per-namespace
 subjects:
   - kind: ServiceAccount
     name: jx-gcpods
     namespace: {{ .Release.Namespace }}
+
+
+{{- range .Values.jxJobsNamespaces }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: gcpods
+  namespace: {{ . }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: gcpods-per-namespace
+subjects:
+  - kind: ServiceAccount
+    name: jx-gcpods
+    namespace: {{ $.Release.Namespace }}
+{{- end }}
+g

--- a/charts/jxboot-helmfile-resources/templates/jx-gcpods-rb.yaml
+++ b/charts/jxboot-helmfile-resources/templates/jx-gcpods-rb.yaml
@@ -44,4 +44,3 @@ subjects:
     name: jx-gcpods
     namespace: {{ $.Release.Namespace }}
 {{- end }}
-g

--- a/charts/jxboot-helmfile-resources/values.yaml
+++ b/charts/jxboot-helmfile-resources/values.yaml
@@ -124,10 +124,12 @@ teamRoles:
 
 gc:
   activities:
+    image: "ghcr.io/jenkins-x/jx-boot"
+    # tag: "latest"
+
     schedule: "0/30 */3 * * *"
     # extraArgs: ["--release-age", "12h0m0s"] will run jx gitops gc activities --release-age 12h0m0s
     extraArgs: []
-    image: "ghcr.io/jenkins-x/jx-boot"
   pods:
     schedule: "0/30 */3 * * *"
     extraArgs: []

--- a/charts/jxboot-helmfile-resources/values.yaml
+++ b/charts/jxboot-helmfile-resources/values.yaml
@@ -16,7 +16,7 @@ lighthouseEngine: tekton
 
 basicAuthSecrets:
   enabled: true
-  
+
 pipeline:
   rbac:
     cluster: true
@@ -127,6 +127,7 @@ gc:
     schedule: "0/30 */3 * * *"
     # extraArgs: ["--release-age", "12h0m0s"] will run jx gitops gc activities --release-age 12h0m0s
     extraArgs: []
+    image: "ghcr.io/jenkins-x/jx-boot"
   pods:
     schedule: "0/30 */3 * * *"
     extraArgs: []

--- a/charts/jxboot-helmfile-resources/values.yaml
+++ b/charts/jxboot-helmfile-resources/values.yaml
@@ -131,6 +131,9 @@ gc:
     # extraArgs: ["--release-age", "12h0m0s"] will run jx gitops gc activities --release-age 12h0m0s
     extraArgs: []
   pods:
+    image: "ghcr.io/jenkins-x/jx-boot"
+    # tag: "latest"
+
     schedule: "0/30 */3 * * *"
     extraArgs: []
   jobs:
@@ -144,6 +147,10 @@ gc:
       ns: "jx-git-operator"
     cronjob:
       ns: "jx-git-operator"
+
+# add extra namespaces to allow garbage collection in those namespaces
+jxJobsNamespaces:
+  - jx
 
 versions:
   # jx is the version of the jx-boot image

--- a/charts/jxboot-helmfile-resources/values.yaml
+++ b/charts/jxboot-helmfile-resources/values.yaml
@@ -148,9 +148,9 @@ gc:
     cronjob:
       ns: "jx-git-operator"
 
-# add extra namespaces to allow garbage collection in those namespaces
-jxJobsNamespaces:
-  - jx
+# adding extra namespaces will allow garbage collection in those namespaces
+jxJobsNamespaces: []
+  #- my-team-ns-2
 
 versions:
   # jx is the version of the jx-boot image


### PR DESCRIPTION
Improves jx-gcactivities, jx-gcpods and jx-gcjobs abilities to operate on multi-namespace pipelines in the cluster, opening ability to use Jenkins X for multi-tenant environment with sensible RBAC restrictions.

**Part of:** https://github.com/jenkins-x/lighthouse/pull/1424
**Requires:** https://github.com/jenkins-x-plugins/jx-gitops/pull/835

Release changelog
===============

Helm chart
---------------

- Parametrized image, to allow usage of custom images

`jx-gcactivities`
--------------------

- By default listen for Lighthouse Activities in all namespaces using new commandline switch `--all-namespaces` introduced in recent PR https://github.com/jenkins-x-plugins/jx-gitops/pull/835
- Changed roles: Namespaced `Role` is for fetching Jenkins X configuration from Jenkins X installation namespace, `ClusterRole` is for tracking and cleaning up Jenkins X pipelines across cluster when using `--all-namespaces` commandline switch

`jx-gcpods`
---------------

- GC pods is granted a `listing` on namespaces, because it will by default look for `Jenkins X` labelled namespaces and clean up pods for all those namespaces. This PR adds a `ClusterRole` to list namespaces. 

- **When adding a new namespace we need to only create a `RoleBinding` for a namespace for which gcpods should work.** 
- **With this pattern gcpods does not have permissions to delete pods in all namespaces but in selected ones.**

- Backwards compatibility: gc-pods can still work in a scope of a single namespace by providing a `--namespace` switch

`jx-gcjobs`
--------------

- Fixed RoleBinding for `gcjobs`, so it allows cleaning up jobs in `jx-git-operator` namespace now