### PR TITLE
WIP: Allowing for the setting of namespace for gcpods

### DIFF
--- a/charts/jxboot-helmfile-resources/templates/jx-gcpods-cronjob.yaml
+++ b/charts/jxboot-helmfile-resources/templates/jx-gcpods-cronjob.yaml
@@ -2,6 +2,7 @@ apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
   name: jx-gcpods
+  namespace: {{ .Values.gc.pods.cronjob.ns | default "jx-git-operator" | quote }}
 spec:
   concurrencyPolicy: Forbid
   failedJobsHistoryLimit: 1

--- a/charts/jxboot-helmfile-resources/templates/jx-gcpods-rb.yaml
+++ b/charts/jxboot-helmfile-resources/templates/jx-gcpods-rb.yaml
@@ -9,4 +9,4 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: jx-gcpods
-    namespace: {{ .Release.Namespace }}
+    namespace: {{ .Values.gc.pods.rb.ns | default "jx-git-operator" | quote }}

--- a/charts/jxboot-helmfile-resources/templates/jx-gcpods-role.yaml
+++ b/charts/jxboot-helmfile-resources/templates/jx-gcpods-role.yaml
@@ -2,6 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: gcpods
+  namespace: {{ .Values.gc.pods.role.ns | default "jx-git-operator" | quote }}
 rules:
   - apiGroups:
       - jenkins.io

--- a/charts/jxboot-helmfile-resources/templates/jx-gcpods-sa.yaml
+++ b/charts/jxboot-helmfile-resources/templates/jx-gcpods-sa.yaml
@@ -2,3 +2,4 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: jx-gcpods
+  namespace: {{ .Values.gc.pods.sa.ns | default "jx-git-operator" | quote }}

--- a/charts/jxboot-helmfile-resources/values.yaml
+++ b/charts/jxboot-helmfile-resources/values.yaml
@@ -122,6 +122,8 @@ teamRoles:
   team-admin:
     enabled: true
 
+# we are including the capability of specifying the pod and job namespace for
+# garbadge collection cronJobs
 gc:
   activities:
     schedule: "0/30 */3 * * *"
@@ -130,6 +132,14 @@ gc:
   pods:
     schedule: "0/30 */3 * * *"
     extraArgs: []
+    rb:
+      ns: "jx-git-operator"
+    sa:
+      ns: "jx-git-operator"
+    role:
+      ns: "jx-git-operator"
+    cronjob:
+      ns: "jx-git-operator"
   jobs:
     schedule: "0/30 */3 * * *"
     extraArgs: ["--namespace", "jx-git-operator"]


### PR DESCRIPTION
The jx-gcjobs components have the capability to set the namespace
but the jx-gcpods do not.  This PR adds that element to all of the
gcpods objects.