### PR TITLE
Add annotations to cronjobs

### DIFF
--- a/charts/jxboot-helmfile-resources/templates/jx-gcactivities-cronjob.yaml
+++ b/charts/jxboot-helmfile-resources/templates/jx-gcactivities-cronjob.yaml
@@ -15,8 +15,11 @@ spec:
           labels:
             app: gcactivities
             release: jxboot-helmfile-resources
-{{- if .Values.gc.activities.annotations }}
           annotations:
+{{- if .Values.istio.enabled }}
+            sidecar.istio.io/inject: "false"
+{{- end }}
+{{- if .Values.gc.activities.annotations }}
 {{ toYaml .Values.gc.activities.annotations | indent 12 }}
 {{- end }}
         spec:

--- a/charts/jxboot-helmfile-resources/templates/jx-gcjobs-cronjob.yaml
+++ b/charts/jxboot-helmfile-resources/templates/jx-gcjobs-cronjob.yaml
@@ -15,8 +15,11 @@ spec:
           labels:
             app: gcjobs
             release: jxboot-helmfile-resources
-{{- if .Values.gc.jobs.annotations }}
           annotations:
+{{- if .Values.istio.enabled }}
+            sidecar.istio.io/inject: "false"
+{{- end }}
+{{- if .Values.gc.jobs.annotations }}
 {{ toYaml .Values.gc.jobs.annotations | indent 12 }}
 {{- end }}
         spec:

--- a/charts/jxboot-helmfile-resources/templates/jx-gcpods-cronjob.yaml
+++ b/charts/jxboot-helmfile-resources/templates/jx-gcpods-cronjob.yaml
@@ -15,8 +15,11 @@ spec:
           labels:
             app: gcpods
             release: jxboot-helmfile-resources
-{{- if .Values.gc.pods.annotations }}
           annotations:
+{{- if .Values.istio.enabled }}
+            sidecar.istio.io/inject: "false"
+{{- end }}
+{{- if .Values.gc.pods.annotations }}
 {{ toYaml .Values.gc.pods.annotations | indent 12 }}
 {{- end }}
         spec:

--- a/charts/jxboot-helmfile-resources/templates/upgrade-cj.yaml
+++ b/charts/jxboot-helmfile-resources/templates/upgrade-cj.yaml
@@ -16,6 +16,10 @@ spec:
         metadata:
           labels:
             app: jenkins-x-updatebot
+          annotations:
+{{- if .Values.istio.enabled }}
+            sidecar.istio.io/inject: "false"
+{{- end }}
         spec:
           initContainers:
             - command:


### PR DESCRIPTION
This prevents istio proxy on the jobs, which can lead to errors in the cj pods