### PR TITLE
fix: switch to cronjob v1 to support kubernetes 1.25+

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,23 +1,4 @@
 approvers:
-- rawlingsj
-- jstrachan
-- rajdavies
-- ccojocar
-- garethjevans
-- pmuir
-- abayer
-- cagiti
-- macox
-- ankitm123
+- maintainers
 reviewers:
-- rawlingsj
-- jstrachan
-- rajdavies
-- ccojocar
-- garethjevans
-- pmuir
-- abayer
-- cagiti
-- macox
-- ankitm123
-
+- maintainers

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,0 +1,3 @@
+foreignAliases:
+- name: jx-community
+  org: jenkins-x

--- a/charts/jxboot-helmfile-resources/templates/jx-gcactivities-cronjob.yaml
+++ b/charts/jxboot-helmfile-resources/templates/jx-gcactivities-cronjob.yaml
@@ -1,4 +1,4 @@
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: jx-gcactivities

--- a/charts/jxboot-helmfile-resources/templates/jx-gcjobs-cronjob.yaml
+++ b/charts/jxboot-helmfile-resources/templates/jx-gcjobs-cronjob.yaml
@@ -1,4 +1,4 @@
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: jx-gcjobs

--- a/charts/jxboot-helmfile-resources/templates/jx-gcpods-cronjob.yaml
+++ b/charts/jxboot-helmfile-resources/templates/jx-gcpods-cronjob.yaml
@@ -1,4 +1,4 @@
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: jx-gcpods

--- a/charts/jxboot-helmfile-resources/templates/upgrade-cj.yaml
+++ b/charts/jxboot-helmfile-resources/templates/upgrade-cj.yaml
@@ -1,5 +1,5 @@
 {{- if eq .Values.jxRequirements.autoUpdate.enabled true }}
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: jx-boot-upgrade

--- a/tests/test_data/bitbucketserver/expected/batch/v1beta1/CronJob/jx-gcactivities.yaml
+++ b/tests/test_data/bitbucketserver/expected/batch/v1beta1/CronJob/jx-gcactivities.yaml
@@ -1,5 +1,5 @@
 # Source: jxboot-helmfile-resources/templates/jx-gcactivities-cronjob.yaml
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: jx-gcactivities

--- a/tests/test_data/bitbucketserver/expected/batch/v1beta1/CronJob/jx-gcpods.yaml
+++ b/tests/test_data/bitbucketserver/expected/batch/v1beta1/CronJob/jx-gcpods.yaml
@@ -1,5 +1,5 @@
 # Source: jxboot-helmfile-resources/templates/jx-gcpods-cronjob.yaml
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: jx-gcpods

--- a/tests/test_data/custom-env/expected/batch/v1beta1/CronJob/jx-gcactivities.yaml
+++ b/tests/test_data/custom-env/expected/batch/v1beta1/CronJob/jx-gcactivities.yaml
@@ -1,5 +1,5 @@
 # Source: jxboot-helmfile-resources/templates/jx-gcactivities-cronjob.yaml
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: jx-gcactivities

--- a/tests/test_data/custom-env/expected/batch/v1beta1/CronJob/jx-gcpods.yaml
+++ b/tests/test_data/custom-env/expected/batch/v1beta1/CronJob/jx-gcpods.yaml
@@ -1,5 +1,5 @@
 # Source: jxboot-helmfile-resources/templates/jx-gcpods-cronjob.yaml
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: jx-gcpods

--- a/tests/test_data/custom-ingress-annotations-all/expected/batch/v1beta1/CronJob/jx-gcactivities.yaml
+++ b/tests/test_data/custom-ingress-annotations-all/expected/batch/v1beta1/CronJob/jx-gcactivities.yaml
@@ -1,5 +1,5 @@
 # Source: jxboot-helmfile-resources/templates/jx-gcactivities-cronjob.yaml
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: jx-gcactivities

--- a/tests/test_data/custom-ingress-annotations-all/expected/batch/v1beta1/CronJob/jx-gcpods.yaml
+++ b/tests/test_data/custom-ingress-annotations-all/expected/batch/v1beta1/CronJob/jx-gcpods.yaml
@@ -1,5 +1,5 @@
 # Source: jxboot-helmfile-resources/templates/jx-gcpods-cronjob.yaml
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: jx-gcpods

--- a/tests/test_data/custom-ingress-annotations/expected/batch/v1beta1/CronJob/jx-gcactivities.yaml
+++ b/tests/test_data/custom-ingress-annotations/expected/batch/v1beta1/CronJob/jx-gcactivities.yaml
@@ -1,5 +1,5 @@
 # Source: jxboot-helmfile-resources/templates/jx-gcactivities-cronjob.yaml
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: jx-gcactivities

--- a/tests/test_data/custom-ingress-annotations/expected/batch/v1beta1/CronJob/jx-gcpods.yaml
+++ b/tests/test_data/custom-ingress-annotations/expected/batch/v1beta1/CronJob/jx-gcpods.yaml
@@ -1,5 +1,5 @@
 # Source: jxboot-helmfile-resources/templates/jx-gcpods-cronjob.yaml
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: jx-gcpods

--- a/tests/test_data/custom-ingress-host/expected/batch/v1beta1/CronJob/jx-gcactivities.yaml
+++ b/tests/test_data/custom-ingress-host/expected/batch/v1beta1/CronJob/jx-gcactivities.yaml
@@ -1,5 +1,5 @@
 # Source: jxboot-helmfile-resources/templates/jx-gcactivities-cronjob.yaml
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: jx-gcactivities

--- a/tests/test_data/custom-ingress-host/expected/batch/v1beta1/CronJob/jx-gcpods.yaml
+++ b/tests/test_data/custom-ingress-host/expected/batch/v1beta1/CronJob/jx-gcpods.yaml
@@ -1,5 +1,5 @@
 # Source: jxboot-helmfile-resources/templates/jx-gcpods-cronjob.yaml
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: jx-gcpods

--- a/tests/test_data/custom-ingress-secret/expected/batch/v1beta1/CronJob/jx-gcactivities.yaml
+++ b/tests/test_data/custom-ingress-secret/expected/batch/v1beta1/CronJob/jx-gcactivities.yaml
@@ -1,5 +1,5 @@
 # Source: jxboot-helmfile-resources/templates/jx-gcactivities-cronjob.yaml
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: jx-gcactivities

--- a/tests/test_data/custom-ingress-secret/expected/batch/v1beta1/CronJob/jx-gcpods.yaml
+++ b/tests/test_data/custom-ingress-secret/expected/batch/v1beta1/CronJob/jx-gcpods.yaml
@@ -1,5 +1,5 @@
 # Source: jxboot-helmfile-resources/templates/jx-gcpods-cronjob.yaml
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: jx-gcpods

--- a/tests/test_data/default/expected/batch/v1beta1/CronJob/jx-gcactivities.yaml
+++ b/tests/test_data/default/expected/batch/v1beta1/CronJob/jx-gcactivities.yaml
@@ -1,5 +1,5 @@
 # Source: jxboot-helmfile-resources/templates/jx-gcactivities-cronjob.yaml
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: jx-gcactivities

--- a/tests/test_data/default/expected/batch/v1beta1/CronJob/jx-gcpods.yaml
+++ b/tests/test_data/default/expected/batch/v1beta1/CronJob/jx-gcpods.yaml
@@ -1,5 +1,5 @@
 # Source: jxboot-helmfile-resources/templates/jx-gcpods-cronjob.yaml
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: jx-gcpods

--- a/tests/test_data/gitlab/expected/batch/v1beta1/CronJob/jx-gcactivities.yaml
+++ b/tests/test_data/gitlab/expected/batch/v1beta1/CronJob/jx-gcactivities.yaml
@@ -1,5 +1,5 @@
 # Source: jxboot-helmfile-resources/templates/jx-gcactivities-cronjob.yaml
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: jx-gcactivities

--- a/tests/test_data/gitlab/expected/batch/v1beta1/CronJob/jx-gcpods.yaml
+++ b/tests/test_data/gitlab/expected/batch/v1beta1/CronJob/jx-gcpods.yaml
@@ -1,5 +1,5 @@
 # Source: jxboot-helmfile-resources/templates/jx-gcpods-cronjob.yaml
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: jx-gcpods

--- a/tests/test_data/gke-domain-bucketrepo/expected/batch/v1beta1/CronJob/jx-gcactivities.yaml
+++ b/tests/test_data/gke-domain-bucketrepo/expected/batch/v1beta1/CronJob/jx-gcactivities.yaml
@@ -1,5 +1,5 @@
 # Source: jxboot-helmfile-resources/templates/jx-gcactivities-cronjob.yaml
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: jx-gcactivities

--- a/tests/test_data/gke-domain-bucketrepo/expected/batch/v1beta1/CronJob/jx-gcpods.yaml
+++ b/tests/test_data/gke-domain-bucketrepo/expected/batch/v1beta1/CronJob/jx-gcpods.yaml
@@ -1,5 +1,5 @@
 # Source: jxboot-helmfile-resources/templates/jx-gcpods-cronjob.yaml
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: jx-gcpods

--- a/tests/test_data/gke-domain-no-repo/expected/batch/v1beta1/CronJob/jx-gcactivities.yaml
+++ b/tests/test_data/gke-domain-no-repo/expected/batch/v1beta1/CronJob/jx-gcactivities.yaml
@@ -1,5 +1,5 @@
 # Source: jxboot-helmfile-resources/templates/jx-gcactivities-cronjob.yaml
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: jx-gcactivities

--- a/tests/test_data/gke-domain-no-repo/expected/batch/v1beta1/CronJob/jx-gcpods.yaml
+++ b/tests/test_data/gke-domain-no-repo/expected/batch/v1beta1/CronJob/jx-gcpods.yaml
@@ -1,5 +1,5 @@
 # Source: jxboot-helmfile-resources/templates/jx-gcpods-cronjob.yaml
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: jx-gcpods

--- a/tests/test_data/gke-domain-none-repo/expected/batch/v1beta1/CronJob/jx-gcactivities.yaml
+++ b/tests/test_data/gke-domain-none-repo/expected/batch/v1beta1/CronJob/jx-gcactivities.yaml
@@ -1,5 +1,5 @@
 # Source: jxboot-helmfile-resources/templates/jx-gcactivities-cronjob.yaml
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: jx-gcactivities

--- a/tests/test_data/gke-domain-none-repo/expected/batch/v1beta1/CronJob/jx-gcpods.yaml
+++ b/tests/test_data/gke-domain-none-repo/expected/batch/v1beta1/CronJob/jx-gcpods.yaml
@@ -1,5 +1,5 @@
 # Source: jxboot-helmfile-resources/templates/jx-gcpods-cronjob.yaml
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: jx-gcpods

--- a/tests/test_data/gke-domain-v1beta1/expected/batch/v1beta1/CronJob/jx-gcactivities.yaml
+++ b/tests/test_data/gke-domain-v1beta1/expected/batch/v1beta1/CronJob/jx-gcactivities.yaml
@@ -1,5 +1,5 @@
 # Source: jxboot-helmfile-resources/templates/jx-gcactivities-cronjob.yaml
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: jx-gcactivities

--- a/tests/test_data/gke-domain-v1beta1/expected/batch/v1beta1/CronJob/jx-gcpods.yaml
+++ b/tests/test_data/gke-domain-v1beta1/expected/batch/v1beta1/CronJob/jx-gcpods.yaml
@@ -1,5 +1,5 @@
 # Source: jxboot-helmfile-resources/templates/jx-gcpods-cronjob.yaml
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: jx-gcpods

--- a/tests/test_data/gke-domain/expected/batch/v1beta1/CronJob/jx-gcactivities.yaml
+++ b/tests/test_data/gke-domain/expected/batch/v1beta1/CronJob/jx-gcactivities.yaml
@@ -1,5 +1,5 @@
 # Source: jxboot-helmfile-resources/templates/jx-gcactivities-cronjob.yaml
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: jx-gcactivities

--- a/tests/test_data/gke-domain/expected/batch/v1beta1/CronJob/jx-gcpods.yaml
+++ b/tests/test_data/gke-domain/expected/batch/v1beta1/CronJob/jx-gcpods.yaml
@@ -1,5 +1,5 @@
 # Source: jxboot-helmfile-resources/templates/jx-gcpods-cronjob.yaml
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: jx-gcpods

--- a/tests/test_data/gke/expected/batch/v1beta1/CronJob/jx-gcactivities.yaml
+++ b/tests/test_data/gke/expected/batch/v1beta1/CronJob/jx-gcactivities.yaml
@@ -1,5 +1,5 @@
 # Source: jxboot-helmfile-resources/templates/jx-gcactivities-cronjob.yaml
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: jx-gcactivities

--- a/tests/test_data/gke/expected/batch/v1beta1/CronJob/jx-gcpods.yaml
+++ b/tests/test_data/gke/expected/batch/v1beta1/CronJob/jx-gcpods.yaml
@@ -1,5 +1,5 @@
 # Source: jxboot-helmfile-resources/templates/jx-gcpods-cronjob.yaml
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: jx-gcpods

--- a/tests/test_data/image-pull-secrets/expected/batch/v1beta1/CronJob/jx-gcactivities.yaml
+++ b/tests/test_data/image-pull-secrets/expected/batch/v1beta1/CronJob/jx-gcactivities.yaml
@@ -1,5 +1,5 @@
 # Source: jxboot-helmfile-resources/templates/jx-gcactivities-cronjob.yaml
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: jx-gcactivities

--- a/tests/test_data/image-pull-secrets/expected/batch/v1beta1/CronJob/jx-gcpods.yaml
+++ b/tests/test_data/image-pull-secrets/expected/batch/v1beta1/CronJob/jx-gcpods.yaml
@@ -1,5 +1,5 @@
 # Source: jxboot-helmfile-resources/templates/jx-gcpods-cronjob.yaml
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: jx-gcpods

--- a/tests/test_data/istio/expected/batch/v1beta1/CronJob/jx-gcactivities.yaml
+++ b/tests/test_data/istio/expected/batch/v1beta1/CronJob/jx-gcactivities.yaml
@@ -1,5 +1,5 @@
 # Source: jxboot-helmfile-resources/templates/jx-gcactivities-cronjob.yaml
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: jx-gcactivities

--- a/tests/test_data/istio/expected/batch/v1beta1/CronJob/jx-gcpods.yaml
+++ b/tests/test_data/istio/expected/batch/v1beta1/CronJob/jx-gcpods.yaml
@@ -1,5 +1,5 @@
 # Source: jxboot-helmfile-resources/templates/jx-gcpods-cronjob.yaml
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: jx-gcpods

--- a/tests/test_data/lighthouse-jx/expected/batch/v1beta1/CronJob/jx-gcactivities.yaml
+++ b/tests/test_data/lighthouse-jx/expected/batch/v1beta1/CronJob/jx-gcactivities.yaml
@@ -1,5 +1,5 @@
 # Source: jxboot-helmfile-resources/templates/jx-gcactivities-cronjob.yaml
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: jx-gcactivities

--- a/tests/test_data/lighthouse-jx/expected/batch/v1beta1/CronJob/jx-gcpods.yaml
+++ b/tests/test_data/lighthouse-jx/expected/batch/v1beta1/CronJob/jx-gcpods.yaml
@@ -1,5 +1,5 @@
 # Source: jxboot-helmfile-resources/templates/jx-gcpods-cronjob.yaml
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: jx-gcpods

--- a/tests/test_data/lighthouse-tekton/expected/batch/v1beta1/CronJob/jx-gcactivities.yaml
+++ b/tests/test_data/lighthouse-tekton/expected/batch/v1beta1/CronJob/jx-gcactivities.yaml
@@ -1,5 +1,5 @@
 # Source: jxboot-helmfile-resources/templates/jx-gcactivities-cronjob.yaml
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: jx-gcactivities

--- a/tests/test_data/lighthouse-tekton/expected/batch/v1beta1/CronJob/jx-gcpods.yaml
+++ b/tests/test_data/lighthouse-tekton/expected/batch/v1beta1/CronJob/jx-gcpods.yaml
@@ -1,5 +1,5 @@
 # Source: jxboot-helmfile-resources/templates/jx-gcpods-cronjob.yaml
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: jx-gcpods

--- a/tests/test_data/no-envs/expected/batch/v1beta1/CronJob/jx-gcactivities.yaml
+++ b/tests/test_data/no-envs/expected/batch/v1beta1/CronJob/jx-gcactivities.yaml
@@ -1,5 +1,5 @@
 # Source: jxboot-helmfile-resources/templates/jx-gcactivities-cronjob.yaml
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: jx-gcactivities

--- a/tests/test_data/no-envs/expected/batch/v1beta1/CronJob/jx-gcpods.yaml
+++ b/tests/test_data/no-envs/expected/batch/v1beta1/CronJob/jx-gcpods.yaml
@@ -1,5 +1,5 @@
 # Source: jxboot-helmfile-resources/templates/jx-gcpods-cronjob.yaml
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: jx-gcpods

--- a/tests/test_data/nodeport/expected/batch/v1beta1/CronJob/jx-gcactivities.yaml
+++ b/tests/test_data/nodeport/expected/batch/v1beta1/CronJob/jx-gcactivities.yaml
@@ -1,5 +1,5 @@
 # Source: jxboot-helmfile-resources/templates/jx-gcactivities-cronjob.yaml
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: jx-gcactivities

--- a/tests/test_data/nodeport/expected/batch/v1beta1/CronJob/jx-gcpods.yaml
+++ b/tests/test_data/nodeport/expected/batch/v1beta1/CronJob/jx-gcpods.yaml
@@ -1,5 +1,5 @@
 # Source: jxboot-helmfile-resources/templates/jx-gcpods-cronjob.yaml
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: jx-gcpods

--- a/tests/test_data/private-repo/expected/batch/v1beta1/CronJob/jx-gcactivities.yaml
+++ b/tests/test_data/private-repo/expected/batch/v1beta1/CronJob/jx-gcactivities.yaml
@@ -1,5 +1,5 @@
 # Source: jxboot-helmfile-resources/templates/jx-gcactivities-cronjob.yaml
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: jx-gcactivities

--- a/tests/test_data/private-repo/expected/batch/v1beta1/CronJob/jx-gcpods.yaml
+++ b/tests/test_data/private-repo/expected/batch/v1beta1/CronJob/jx-gcpods.yaml
@@ -1,5 +1,5 @@
 # Source: jxboot-helmfile-resources/templates/jx-gcpods-cronjob.yaml
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: jx-gcpods

--- a/tests/test_data/remote-env/expected/batch/v1beta1/CronJob/jx-gcactivities.yaml
+++ b/tests/test_data/remote-env/expected/batch/v1beta1/CronJob/jx-gcactivities.yaml
@@ -1,5 +1,5 @@
 # Source: jxboot-helmfile-resources/templates/jx-gcactivities-cronjob.yaml
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: jx-gcactivities

--- a/tests/test_data/remote-env/expected/batch/v1beta1/CronJob/jx-gcpods.yaml
+++ b/tests/test_data/remote-env/expected/batch/v1beta1/CronJob/jx-gcpods.yaml
@@ -1,5 +1,5 @@
 # Source: jxboot-helmfile-resources/templates/jx-gcpods-cronjob.yaml
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: jx-gcpods

--- a/tests/test_data/upgrade/expected/batch/v1beta1/CronJob/jx-boot-upgrade.yaml
+++ b/tests/test_data/upgrade/expected/batch/v1beta1/CronJob/jx-boot-upgrade.yaml
@@ -1,5 +1,5 @@
 # Source: jxboot-helmfile-resources/templates/upgrade-cj.yaml
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: jx-boot-upgrade

--- a/tests/test_data/upgrade/expected/batch/v1beta1/CronJob/jx-gcactivities.yaml
+++ b/tests/test_data/upgrade/expected/batch/v1beta1/CronJob/jx-gcactivities.yaml
@@ -1,5 +1,5 @@
 # Source: jxboot-helmfile-resources/templates/jx-gcactivities-cronjob.yaml
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: jx-gcactivities

--- a/tests/test_data/upgrade/expected/batch/v1beta1/CronJob/jx-gcpods.yaml
+++ b/tests/test_data/upgrade/expected/batch/v1beta1/CronJob/jx-gcpods.yaml
@@ -1,5 +1,5 @@
 # Source: jxboot-helmfile-resources/templates/jx-gcpods-cronjob.yaml
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: jx-gcpods


### PR DESCRIPTION
Signed-off-by: ankitm123 <ankitmohapatra123@gmail.com>

We dont support kubernetes < 1,21 anyways, so this should not break existing jx installations.