### PR TITLE
feat: Make ingress annotations customisable

### DIFF
--- a/charts/jxboot-helmfile-resources/templates/700-bucketrepo-ing.yaml
+++ b/charts/jxboot-helmfile-resources/templates/700-bucketrepo-ing.yaml
@@ -23,18 +23,22 @@ spec:
 {{- end }}
 {{- if eq "NodePort" .Values.jxRequirements.ingress.serviceType }}
         path: "/bucketrepo"
+{{- else if .Values.bucketrepo.ingress.customHost }}
+    host: {{ .Values.bucketrepo.ingress.customHost }}
 {{- else if .Values.ingress.customHosts.bucketrepo }}
     host: {{ .Values.ingress.customHosts.bucketrepo }}
 {{- else if .Values.jxRequirements.ingress.domain }}
-    host: {{ .Values.ingress.prefix.bucketrepo }}{{ .Values.jxRequirements.ingress.namespaceSubDomain }}{{ .Values.jxRequirements.ingress.domain }}
+    host: {{ .Values.ingress.prefix.bucketrepo | default .Values.bucketrepo.ingress.prefix }}{{ .Values.jxRequirements.ingress.namespaceSubDomain }}{{ .Values.jxRequirements.ingress.domain }}
 {{- end }}
 {{- if .Values.jxRequirements.ingress.tls.enabled }}
   tls:
   - hosts:
-  {{- if .Values.ingress.customHosts.bucketrepo }}
+  {{- if .Values.bucketrepo.ingress.customHost }}
+    - {{ .Values.bucketrepo.ingress.customHost }}
+  {{- else if .Values.ingress.customHosts.bucketrepo }}
     - {{ .Values.ingress.customHosts.bucketrepo }}
   {{- else }}
-    - {{ .Values.ingress.prefix.bucketrepo }}{{ .Values.jxRequirements.ingress.namespaceSubDomain }}{{ .Values.jxRequirements.ingress.domain }}
+    - {{ .Values.ingress.prefix.bucketrepo | default.Values.bucketrepo.ingress.prefix }}{{ .Values.jxRequirements.ingress.namespaceSubDomain }}{{ .Values.jxRequirements.ingress.domain }}
   {{- end }}
 {{- if .Values.bucketrepo.ingress.tls.secretName }}
     secretName: "{{ .Values.bucketrepo.ingress.tls.secretName }}"

--- a/charts/jxboot-helmfile-resources/templates/700-chartmuseum-ing.yaml
+++ b/charts/jxboot-helmfile-resources/templates/700-chartmuseum-ing.yaml
@@ -23,18 +23,22 @@ spec:
 {{- end }}
 {{- if eq "NodePort" .Values.jxRequirements.ingress.serviceType }}
         path: "/chartmuseum"
+{{- else if .Values.chartmuseum.ingress.customHost }}
+    host: {{ .Values.chartmuseum.ingress.customHost }}
 {{- else if .Values.ingress.customHosts.chartmuseum }}
     host: {{ .Values.ingress.customHosts.chartmuseum }}
 {{- else if .Values.jxRequirements.ingress.domain }}
-    host: {{ .Values.ingress.prefix.chartmuseum }}{{ .Values.jxRequirements.ingress.namespaceSubDomain }}{{ .Values.jxRequirements.ingress.domain }}
+    host: {{ .Values.ingress.prefix.chartmuseum | default .Values.chartmuseum.ingress.prefix }}{{ .Values.jxRequirements.ingress.namespaceSubDomain }}{{ .Values.jxRequirements.ingress.domain }}
 {{- end }}
 {{- if .Values.jxRequirements.ingress.tls.enabled }}
   tls:
   - hosts:
-  {{- if .Values.ingress.customHosts.chartmuseum }}
+  {{- if .Values.chartmuseum.ingress.customHost }}
+    - {{ .Values.chartmuseum.ingress.customHost }}
+  {{- else if .Values.ingress.customHosts.chartmuseum }}
     - {{ .Values.ingress.customHosts.chartmuseum }}
   {{- else }}
-    - {{ .Values.ingress.prefix.chartmuseum }}{{ .Values.jxRequirements.ingress.namespaceSubDomain }}{{ .Values.jxRequirements.ingress.domain }}
+    - {{ .Values.ingress.prefix.chartmuseum | default .Values.chartmuseum.ingress.prefix }}{{ .Values.jxRequirements.ingress.namespaceSubDomain }}{{ .Values.jxRequirements.ingress.domain }}
   {{- end }}
 {{- if .Values.chartmuseum.ingress.tls.secretName }}
     secretName: "{{ .Values.chartmuseum.ingress.tls.secretName }}"

--- a/charts/jxboot-helmfile-resources/templates/700-docker-ing.yaml
+++ b/charts/jxboot-helmfile-resources/templates/700-docker-ing.yaml
@@ -3,7 +3,7 @@ apiVersion: {{ .Values.ingress.apiVersion | default "networking.k8s.io/v1" }}
 kind: Ingress
 metadata:
   annotations:
-{{- template "ingressAnnotations" (dict "Values" .Values "component" "dockerRegistry") }}
+{{- template "ingressAnnotations" (dict "Values" .Values "component" "docker-registry") }}
   name: docker-registry
 spec:
   rules:
@@ -23,18 +23,22 @@ spec:
 {{- end }}
 {{- if eq "NodePort" .Values.jxRequirements.ingress.serviceType }}
         path: "/docker-registry"
+{{- else if index .Values "docker-registry" "ingress" "customHost" }}
+    host: {{ index .Values "docker-registry" "ingress" "customHost" }}
 {{- else if .Values.ingress.customHosts.dockerRegistry }}
     host: {{ .Values.ingress.customHosts.dockerRegistry }}
 {{- else if .Values.jxRequirements.ingress.domain }}
-    host: {{ .Values.ingress.prefix.dockerRegistry }}{{ .Values.jxRequirements.ingress.namespaceSubDomain }}{{ .Values.jxRequirements.ingress.domain }}
+    host: {{ .Values.ingress.prefix.dockerRegistry | default (index .Values "docker-registry" "ingress" "prefix") }}{{ .Values.jxRequirements.ingress.namespaceSubDomain }}{{ .Values.jxRequirements.ingress.domain }}
 {{- end }}
 {{- if .Values.jxRequirements.ingress.tls.enabled }}
   tls:
   - hosts:
-  {{- if .Values.ingress.customHosts.dockerRegistry }}
+  {{- if index .Values "docker-registry" "ingress" "customHost" }}
+    - {{ index .Values "docker-registry" "ingress" "customHost" }}
+  {{- else if .Values.ingress.customHosts.dockerRegistry }}
     - {{ .Values.ingress.customHosts.dockerRegistry }}
   {{- else }}
-    - {{ .Values.ingress.prefix.dockerRegistry }}{{ .Values.jxRequirements.ingress.namespaceSubDomain }}{{ .Values.jxRequirements.ingress.domain }}
+    - {{ .Values.ingress.prefix.dockerRegistry | default (index .Values "docker-registry" "ingress" "prefix") }}{{ .Values.jxRequirements.ingress.namespaceSubDomain }}{{ .Values.jxRequirements.ingress.domain }}
   {{- end }}
 {{- if index .Values "docker-registry" "ingress" "tls" "secretName" }}
     secretName: "{{ index .Values "docker-registry" "ingress" "tls" "secretName" }}"

--- a/charts/jxboot-helmfile-resources/templates/700-hook-ing.yaml
+++ b/charts/jxboot-helmfile-resources/templates/700-hook-ing.yaml
@@ -22,18 +22,22 @@ spec:
               number: 80
 {{- end }}
         path: "/hook"
-{{- if .Values.ingress.customHosts.hook }}
+{{- if .Values.hook.ingress.customHost }}
+    host: {{ .Values.hook.ingress.customHost }}
+{{- else if .Values.ingress.customHosts.hook }}
     host: {{ .Values.ingress.customHosts.hook }}
 {{- else if .Values.jxRequirements.ingress.domain }}
-    host: {{ .Values.ingress.prefix.hook }}{{ .Values.jxRequirements.ingress.namespaceSubDomain }}{{ .Values.jxRequirements.ingress.domain }}
+    host: {{ .Values.ingress.prefix.hook | default .Values.hook.ingress.prefix }}{{ .Values.jxRequirements.ingress.namespaceSubDomain }}{{ .Values.jxRequirements.ingress.domain }}
 {{- end }}
 {{- if .Values.jxRequirements.ingress.tls.enabled }}
   tls:
   - hosts:
-  {{- if .Values.ingress.customHosts.hook }}
+  {{- if .Values.hook.ingress.customHost }}
+    - {{ .Values.hook.ingress.customHost }}
+  {{- else if .Values.ingress.customHosts.hook }}
     - {{ .Values.ingress.customHosts.hook }}
   {{- else }}
-    - {{ .Values.ingress.prefix.hook }}{{ .Values.jxRequirements.ingress.namespaceSubDomain }}{{ .Values.jxRequirements.ingress.domain }}
+    - {{ .Values.ingress.prefix.hook | default .Values.hook.ingress.prefix }}{{ .Values.jxRequirements.ingress.namespaceSubDomain }}{{ .Values.jxRequirements.ingress.domain }}
   {{- end }}
 {{- if .Values.hook.ingress.tls.secretName }}
     secretName: "{{ .Values.hook.ingress.tls.secretName }}"

--- a/charts/jxboot-helmfile-resources/templates/700-nexus-ing.yaml
+++ b/charts/jxboot-helmfile-resources/templates/700-nexus-ing.yaml
@@ -23,18 +23,22 @@ spec:
 {{- end }}
 {{- if eq "NodePort" .Values.jxRequirements.ingress.serviceType }}
         path: "/nexus"
+{{- else if .Values.nexus.ingress.customHost }}
+    host: {{ .Values.nexus.ingress.customHost }}
 {{- else if .Values.ingress.customHosts.nexus }}
     host: {{ .Values.ingress.customHosts.nexus }}
 {{- else if .Values.jxRequirements.ingress.domain }}
-    host: {{ .Values.ingress.prefix.nexus }}{{ .Values.jxRequirements.ingress.namespaceSubDomain }}{{ .Values.jxRequirements.ingress.domain }}
+    host: {{ .Values.ingress.prefix.nexus | default .Values.nexus.ingress.prefix }}{{ .Values.jxRequirements.ingress.namespaceSubDomain }}{{ .Values.jxRequirements.ingress.domain }}
 {{- end }}
 {{- if .Values.jxRequirements.ingress.tls.enabled }}
   tls:
   - hosts:
-  {{- if .Values.ingress.customHosts.nexus }}
+  {{- if .Values.nexus.ingress.customHost }}
+    - {{ .Values.nexus.ingress.customHost }}
+  {{- else if .Values.ingress.customHosts.nexus }}
     - {{ .Values.ingress.customHosts.nexus }}
   {{- else }}
-    - {{ .Values.ingress.prefix.nexus }}{{ .Values.jxRequirements.ingress.namespaceSubDomain }}{{ .Values.jxRequirements.ingress.domain }}
+    - {{ .Values.ingress.prefix.nexus | default .Values.nexus.ingress.prefix }}{{ .Values.jxRequirements.ingress.namespaceSubDomain }}{{ .Values.jxRequirements.ingress.domain }}
   {{- end }}
 {{- if .Values.nexus.ingress.tls.secretName }}
     secretName: "{{ .Values.nexus.ingress.tls.secretName }}"

--- a/charts/jxboot-helmfile-resources/templates/_helpers.tpl
+++ b/charts/jxboot-helmfile-resources/templates/_helpers.tpl
@@ -1,14 +1,32 @@
 {{- define "ingressAnnotations" }}
-{{- $annotations := dict }}
-{{- $_ := merge $annotations .Values.ingress.annotations .Values.jxRequirements.ingress.annotations  }}
-{{- if not (hasKey $annotations "kubernetes.io/ingress.class") }}
-{{- $customIngressClass := index .Values.ingress.customIngressClass .component }}
-{{- $_ := set $annotations "kubernetes.io/ingress.class" ($customIngressClass | default "nginx") }}
-{{- end }}
-{{- if and (hasKey .Values.jxRequirements.ingress "serviceType") (.Values.jxRequirements.ingress.serviceType) (eq .Values.jxRequirements.ingress.serviceType "NodePort") (not (hasKey $annotations "jenkins.io/host")) }}
-{{- $_ := set $annotations "jenkins.io/host" .Values.jxRequirements.ingress.domain }}
-{{- end }}
-{{- if $annotations }}
+  {{- $annotations := dict }}
+  {{- $componentSpec := index .Values .component }}
+
+  {{- if hasKey $componentSpec.ingress "annotations" }}
+    {{- $_ := merge $annotations $componentSpec.ingress.annotations }}
+  {{- end }}
+
+  {{- $_ := merge $annotations .Values.ingress.annotations .Values.jxRequirements.ingress.annotations  }}
+
+  {{- if not (hasKey $annotations "kubernetes.io/ingress.class") }}
+    {{- $customIngressClass := "" }}
+    {{- if $componentSpec.ingress.customIngressClass }}
+      {{- $customIngressClass := $componentSpec.ingress.customIngressClass }}
+    {{- else if hasKey .Values.ingress "customIngressClass" }}
+      {{- if eq .component "docker-registry" }}
+        {{- if hasKey .Values.ingress.customIngressClass "dockerRegistry" }}
+          {{- $customIngressClass := index .Values.ingress.customIngressClass "dockerRegistry" }}
+        {{- end }}
+      {{- else if hasKey .Values.ingress.customIngressClass .component }}
+        {{- $customIngressClass := index .Values.ingress.customIngressClass .component }}
+      {{- end }}
+    {{- end }}
+    {{- $_ := set $annotations "kubernetes.io/ingress.class" ($customIngressClass | default "nginx")  }}
+  {{- end }}
+  {{- if and (hasKey .Values.jxRequirements.ingress "serviceType") (.Values.jxRequirements.ingress.serviceType) (eq .Values.jxRequirements.ingress.serviceType "NodePort") (not (hasKey $annotations "jenkins.io/host")) }}
+   {{- $_ := set $annotations "jenkins.io/host" .Values.jxRequirements.ingress.domain }}
+  {{- end }}
+  {{- if $annotations }}
 {{ toYaml $annotations | indent 4 }}
+  {{- end }}
 {{- end }}
-{{- end -}}

--- a/charts/jxboot-helmfile-resources/values.yaml
+++ b/charts/jxboot-helmfile-resources/values.yaml
@@ -16,7 +16,7 @@ lighthouseEngine: tekton
 
 basicAuthSecrets:
   enabled: true
-  
+
 pipeline:
   rbac:
     cluster: true
@@ -44,27 +44,47 @@ pipeline:
 
 bucketrepo:
   ingress:
+    annotations: {}
+    customHost: "" # setting this will override the value from .Values.ingress.customHost.bucketrepo
+    customIngressClass: "" # setting this will override the value from .Values.ingress.customIngressClass.bucketrepo
+    prefix: bucketrepo
     tls:
       secretName: ""
 
 chartmuseum:
   ingress:
+    annotations: {}
+    customHost: "" # setting this will override the value from .Values.ingress.customHost.chartmuseum
+    customIngressClass: "" # setting this will override the value from .Values.ingress.customIngressClass.chartmuseum
+    prefix: chartmuseum
     tls:
       secretName: ""
 
 docker-registry:
   enabled: false
   ingress:
+    annotations: {}
+    customHost: "" # setting this will override the value from .Values.ingress.customHost.dockerRegistry
+    customIngressClass: "" # setting this will override the value from .Values.ingress.customIngressClass.dockerRegistry
+    prefix: docker-registry
     tls:
       secretName: ""
 
 hook:
   ingress:
+    annotations: {}
+    customHost: "" # setting this will override the value from .Values.ingress.customHost.hook
+    customIngressClass: "" # setting this will override the value from .Values.ingress.customIngressClass.hook
+    prefix: hook
     tls:
       secretName: ""
 
 nexus:
   ingress:
+    annotations: {}
+    customHost: "" # setting this will override the value from .Values.ingress.customHost.nexus
+    customIngressClass: "" # setting this will override the value from .Values.ingress.customIngressClass.nexus
+    prefix: nexus # setting this will override the value from .Values.ingress.prefix.nexus
     tls:
       secretName: ""
 
@@ -86,29 +106,29 @@ ingress:
   pathType: ImplementationSpecific
 
 
-  # define the ingress prefixes for the different services
-  prefix:
-    bucketrepo: bucketrepo
-    chartmuseum: chartmuseum
-    hook: hook
-    nexus: nexus
-    dockerRegistry: docker-registry
+  # define the ingress prefixes for the different services (deprecated in favour of .Values.<component>.ingress.prefix)
+  prefix: {}
+    # bucketrepo: bucketrepo
+    # chartmuseum: chartmuseum
+    # hook: hook
+    # nexus: nexus
+    # dockerRegistry: docker-registry
 
-  # allows you to specify custom hosts
-  customHosts:
-    bucketrepo: ""
-    chartmuseum: ""
-    hook: ""
-    nexus: ""
-    dockerRegistry: ""
+  # allows you to specify custom hosts (deprecated in favour of .Values.<component>.ingress.customHost)
+  customHosts: {}
+    # bucketrepo: ""
+    # chartmuseum: ""
+    # hook: ""
+    # nexus: ""
+    # dockerRegistry: ""
 
-  # allows you to specify custom ingress class
-  customIngressClass:
-    bucketrepo: ""
-    chartmuseum: ""
-    hook: ""
-    nexus: ""
-    dockerRegistry: ""
+  # allows you to specify custom ingress class (deprecated in favour of .Values.<component>.ingress.customIngressClass)
+  customIngressClass: {}
+  #   bucketrepo: ""
+  #   chartmuseum: ""
+  #   hook: ""
+  #   nexus: ""
+  #   dockerRegistry: ""
 
 nexusServiceLink:
   enabled: false


### PR DESCRIPTION
Also allow all customisations for a service to live in a single dictionary
whilst retaining existing customisations

With this change, the place to make customisations for the ingresses goes from using multiple dictionaries to a single dictionary for each service

```
servicename:
  ingress:
    annotations:
      <key>: value
    customHost: <whatever>
    customingressClass: <whatever>
    prefix: <whatever>
    tls:
      secretName: <whatever>
```

This change is backwards compatible, so where customisations have been set in repo values files the old way, these will still override the chart values