### PR TITLE
fix: typo in bucketrepo default hosts

### DIFF
--- a/charts/jxboot-helmfile-resources/templates/700-bucketrepo-ing.yaml
+++ b/charts/jxboot-helmfile-resources/templates/700-bucketrepo-ing.yaml
@@ -38,7 +38,7 @@ spec:
   {{- else if .Values.ingress.customHosts.bucketrepo }}
     - {{ .Values.ingress.customHosts.bucketrepo }}
   {{- else }}
-    - {{ .Values.ingress.prefix.bucketrepo | default.Values.bucketrepo.ingress.prefix }}{{ .Values.jxRequirements.ingress.namespaceSubDomain }}{{ .Values.jxRequirements.ingress.domain }}
+    - {{ .Values.ingress.prefix.bucketrepo | default .Values.bucketrepo.ingress.prefix }}{{ .Values.jxRequirements.ingress.namespaceSubDomain }}{{ .Values.jxRequirements.ingress.domain }}
   {{- end }}
 {{- if .Values.bucketrepo.ingress.tls.secretName }}
     secretName: "{{ .Values.bucketrepo.ingress.tls.secretName }}"


### PR DESCRIPTION
post https://github.com/jenkins-x-charts/jxboot-helmfile-resources/pull/648, this helmfile
```
- chart: jxgh/jxboot-helmfile-resources
  version: 1.1.290
  name: jxboot-helmfile-resources
  values:
  - ../../versionStream/charts/jxgh/jxboot-helmfile-resources/values.yaml.gotmpl
  - jx-values.yaml
  - hook-values.yaml.gotmpl
  ```
and these values
```
hook:
  ingress:
    customIngressClass: nginx-public
```
result in
```
Templating release=jxboot-helmfile-resources, chart=jxgh/jxboot-helmfile-resources
in ./helmfile.yaml: in .helmfiles[8]: in helmfiles/jx/helmfile.yaml: command "/usr/bin/helm" exited with non-zero status:
PATH:
  /usr/bin/helm
ARGS:
  0: helm (4 bytes)
  1: template (8 bytes)
  2: jxboot-helmfile-resources (25 bytes)
  3: jxgh/jxboot-helmfile-resources (30 bytes)
  4: --version (9 bytes)
  5: 1.1.290 (7 bytes)
  6: --namespace (11 bytes)
  7: jx (2 bytes)
  8: --values (8 bytes)
  9: /tmp/helmfile993382711/jx-jxboot-helmfile-resources-values-654575d784 (69 bytes)
  10: --values (8 bytes)
  11: /tmp/helmfile3571633976/jx-jxboot-helmfile-resources-values-5c469f5858 (70 bytes)
  12: --values (8 bytes)
  13: /tmp/helmfile1913977198/jx-jxboot-helmfile-resources-values-7b9cd7bc97 (70 bytes)
  14: --output-dir (12 bytes)
  15: /tmp/generate/jx/jxboot-helmfile-resources (42 bytes)
  16: --validate (10 bytes)
  17: --include-crds (14 bytes)
  18: --skip-tests (12 bytes)
ERROR:
  exit status 1
EXIT STATUS
  1
STDERR:
  Error: template: jxboot-helmfile-resources/templates/700-bucketrepo-ing.yaml:41:45: executing "jxboot-helmfile-resources/templates/700-bucketrepo-ing.yaml" at <default>: wrong number of args for default: want at least 1 got 0
  Use --debug flag to render out invalid YAML
COMBINED OUTPUT:
  Error: template: jxboot-helmfile-resources/templates/700-bucketrepo-ing.yaml:41:45: executing "jxboot-helmfile-resources/templates/700-bucketrepo-ing.yaml" at <default>: wrong number of args for default: want at least 1 got 0
  Use --debug flag to render out invalid YAML
```
when bucketrepo is enabled. oddly, there is already a test case for bucketrepo in the tests folder
