### PR TITLE
chore: add test step to pullrequest pipeline

### DIFF
--- a/.lighthouse/jenkins-x/pullrequest.yaml
+++ b/.lighthouse/jenkins-x/pullrequest.yaml
@@ -21,6 +21,16 @@ spec:
           resources: {}
         - name: jx-variables
           resources: {}
+        - name: build-make-test
+          image: uses:jenkins-x/jx3-pipeline-catalog/tasks/go-cli/pullrequest.yaml@versionStream
+          resources: {}
+          script: |
+            #!/bin/sh
+            curl https://baltocdn.com/helm/signing.asc | gpg --dearmor | tee /usr/share/keyrings/helm.gpg > /dev/null
+            echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/helm.gpg] https://baltocdn.com/helm/stable/debian/ all main" | tee /etc/apt/sources.list.d/helm-stable-debian.list
+            apt-get update
+            apt-get install helm
+            make test
         - name: build-helm-build
           resources: {}
   podTemplate: {}

--- a/tests/test_data/bitbucketserver/expected/batch/v1/CronJob/jx-gcactivities.yaml
+++ b/tests/test_data/bitbucketserver/expected/batch/v1/CronJob/jx-gcactivities.yaml
@@ -28,7 +28,7 @@ spec:
                 - gc
                 - activities
               imagePullPolicy: IfNotPresent
-              image: "ghcr.io/jenkins-x/jx-boot:3.10.70"
+              image: "ghcr.io/jenkins-x/jx-boot:TESTVAL"
               env:
                 - name: JX_LOG_FORMAT
                   value: json

--- a/tests/test_data/bitbucketserver/expected/batch/v1/CronJob/jx-gcjobs.yaml
+++ b/tests/test_data/bitbucketserver/expected/batch/v1/CronJob/jx-gcjobs.yaml
@@ -30,7 +30,7 @@ spec:
                 - --namespace
                 - jx-git-operator
               imagePullPolicy: IfNotPresent
-              image: "ghcr.io/jenkins-x/jx-boot:3.10.70"
+              image: "ghcr.io/jenkins-x/jx-boot:TESTVAL"
               env:
                 - name: JX_LOG_FORMAT
                   value: json

--- a/tests/test_data/bitbucketserver/expected/batch/v1/CronJob/jx-gcpods.yaml
+++ b/tests/test_data/bitbucketserver/expected/batch/v1/CronJob/jx-gcpods.yaml
@@ -28,7 +28,7 @@ spec:
                 - gc
                 - pods
               imagePullPolicy: IfNotPresent
-              image: "ghcr.io/jenkins-x/jx-boot:3.10.70"
+              image: "ghcr.io/jenkins-x/jx-boot:TESTVAL"
               env:
                 - name: JX_LOG_FORMAT
                   value: json

--- a/tests/test_data/bitbucketserver/values/jxRequirements.values.yaml
+++ b/tests/test_data/bitbucketserver/values/jxRequirements.values.yaml
@@ -1,6 +1,11 @@
 versions:
   # TODO update with latest builders version
   builders: latest
+  # we set the versions of jx & updatebot to TESTVAL
+  # in order to ensure tests are deterministic
+  # (templated file content doesn't change just because new versions are released)
+  jx: TESTVAL
+  updatebot: TESTVAL
 
 # TODO we want to remove exposecontroller at some point
 exposer: Ingress

--- a/tests/test_data/cronjob-jx-gcactivities-quoted-args/expected/batch/v1/CronJob/jx-gcactivities.yaml
+++ b/tests/test_data/cronjob-jx-gcactivities-quoted-args/expected/batch/v1/CronJob/jx-gcactivities.yaml
@@ -32,7 +32,7 @@ spec:
                 - "--release-history-limit"
                 - "10"
               imagePullPolicy: IfNotPresent
-              image: "ghcr.io/jenkins-x/jx-boot:3.10.70"
+              image: "ghcr.io/jenkins-x/jx-boot:TESTVAL"
               env:
                 - name: JX_LOG_FORMAT
                   value: json

--- a/tests/test_data/cronjob-jx-gcactivities-quoted-args/expected/batch/v1/CronJob/jx-gcjobs.yaml
+++ b/tests/test_data/cronjob-jx-gcactivities-quoted-args/expected/batch/v1/CronJob/jx-gcjobs.yaml
@@ -30,7 +30,7 @@ spec:
                 - --namespace
                 - jx-git-operator
               imagePullPolicy: IfNotPresent
-              image: "ghcr.io/jenkins-x/jx-boot:3.10.70"
+              image: "ghcr.io/jenkins-x/jx-boot:TESTVAL"
               env:
                 - name: JX_LOG_FORMAT
                   value: json

--- a/tests/test_data/cronjob-jx-gcactivities-quoted-args/expected/batch/v1/CronJob/jx-gcpods.yaml
+++ b/tests/test_data/cronjob-jx-gcactivities-quoted-args/expected/batch/v1/CronJob/jx-gcpods.yaml
@@ -28,7 +28,7 @@ spec:
                 - gc
                 - pods
               imagePullPolicy: IfNotPresent
-              image: "ghcr.io/jenkins-x/jx-boot:3.10.70"
+              image: "ghcr.io/jenkins-x/jx-boot:TESTVAL"
               env:
                 - name: JX_LOG_FORMAT
                   value: json

--- a/tests/test_data/cronjob-jx-gcactivities-quoted-args/values/jxRequirements.values.yaml
+++ b/tests/test_data/cronjob-jx-gcactivities-quoted-args/values/jxRequirements.values.yaml
@@ -1,6 +1,11 @@
 versions:
   # TODO update with latest builders version
   builders: latest
+  # we set the versions of jx & updatebot to TESTVAL
+  # in order to ensure tests are deterministic
+  # (templated file content doesn't change just because new versions are released)
+  jx: TESTVAL
+  updatebot: TESTVAL
 
 # TODO we want to remove exposecontroller at some point
 exposer: Ingress

--- a/tests/test_data/custom-env/expected/batch/v1/CronJob/jx-gcactivities.yaml
+++ b/tests/test_data/custom-env/expected/batch/v1/CronJob/jx-gcactivities.yaml
@@ -28,7 +28,7 @@ spec:
                 - gc
                 - activities
               imagePullPolicy: IfNotPresent
-              image: "ghcr.io/jenkins-x/jx-boot:3.10.70"
+              image: "ghcr.io/jenkins-x/jx-boot:TESTVAL"
               env:
                 - name: JX_LOG_FORMAT
                   value: json

--- a/tests/test_data/custom-env/expected/batch/v1/CronJob/jx-gcjobs.yaml
+++ b/tests/test_data/custom-env/expected/batch/v1/CronJob/jx-gcjobs.yaml
@@ -30,7 +30,7 @@ spec:
                 - --namespace
                 - jx-git-operator
               imagePullPolicy: IfNotPresent
-              image: "ghcr.io/jenkins-x/jx-boot:3.10.70"
+              image: "ghcr.io/jenkins-x/jx-boot:TESTVAL"
               env:
                 - name: JX_LOG_FORMAT
                   value: json

--- a/tests/test_data/custom-env/expected/batch/v1/CronJob/jx-gcpods.yaml
+++ b/tests/test_data/custom-env/expected/batch/v1/CronJob/jx-gcpods.yaml
@@ -28,7 +28,7 @@ spec:
                 - gc
                 - pods
               imagePullPolicy: IfNotPresent
-              image: "ghcr.io/jenkins-x/jx-boot:3.10.70"
+              image: "ghcr.io/jenkins-x/jx-boot:TESTVAL"
               env:
                 - name: JX_LOG_FORMAT
                   value: json

--- a/tests/test_data/custom-env/values/jxRequirements.values.yaml
+++ b/tests/test_data/custom-env/values/jxRequirements.values.yaml
@@ -1,6 +1,11 @@
 versions:
   # TODO update with latest builders version
   builders: latest
+  # we set the versions of jx & updatebot to TESTVAL
+  # in order to ensure tests are deterministic
+  # (templated file content doesn't change just because new versions are released)
+  jx: TESTVAL
+  updatebot: TESTVAL
 
 # TODO we want to remove exposecontroller at some point
 exposer: Ingress

--- a/tests/test_data/custom-ingress-annotations-all/expected/batch/v1/CronJob/jx-gcactivities.yaml
+++ b/tests/test_data/custom-ingress-annotations-all/expected/batch/v1/CronJob/jx-gcactivities.yaml
@@ -28,7 +28,7 @@ spec:
                 - gc
                 - activities
               imagePullPolicy: IfNotPresent
-              image: "ghcr.io/jenkins-x/jx-boot:3.10.70"
+              image: "ghcr.io/jenkins-x/jx-boot:TESTVAL"
               env:
                 - name: JX_LOG_FORMAT
                   value: json

--- a/tests/test_data/custom-ingress-annotations-all/expected/batch/v1/CronJob/jx-gcjobs.yaml
+++ b/tests/test_data/custom-ingress-annotations-all/expected/batch/v1/CronJob/jx-gcjobs.yaml
@@ -30,7 +30,7 @@ spec:
                 - --namespace
                 - jx-git-operator
               imagePullPolicy: IfNotPresent
-              image: "ghcr.io/jenkins-x/jx-boot:3.10.70"
+              image: "ghcr.io/jenkins-x/jx-boot:TESTVAL"
               env:
                 - name: JX_LOG_FORMAT
                   value: json

--- a/tests/test_data/custom-ingress-annotations-all/expected/batch/v1/CronJob/jx-gcpods.yaml
+++ b/tests/test_data/custom-ingress-annotations-all/expected/batch/v1/CronJob/jx-gcpods.yaml
@@ -28,7 +28,7 @@ spec:
                 - gc
                 - pods
               imagePullPolicy: IfNotPresent
-              image: "ghcr.io/jenkins-x/jx-boot:3.10.70"
+              image: "ghcr.io/jenkins-x/jx-boot:TESTVAL"
               env:
                 - name: JX_LOG_FORMAT
                   value: json

--- a/tests/test_data/custom-ingress-annotations-all/values/jxRequirements.values.yaml
+++ b/tests/test_data/custom-ingress-annotations-all/values/jxRequirements.values.yaml
@@ -1,6 +1,11 @@
 versions:
   # TODO update with latest builders version
   builders: latest
+  # we set the versions of jx & updatebot to TESTVAL
+  # in order to ensure tests are deterministic
+  # (templated file content doesn't change just because new versions are released)
+  jx: TESTVAL
+  updatebot: TESTVAL
 
 # TODO we want to remove exposecontroller at some point
 exposer: Ingress

--- a/tests/test_data/custom-ingress-annotations-new/expected/batch/v1/CronJob/jx-gcactivities.yaml
+++ b/tests/test_data/custom-ingress-annotations-new/expected/batch/v1/CronJob/jx-gcactivities.yaml
@@ -28,7 +28,7 @@ spec:
                 - gc
                 - activities
               imagePullPolicy: IfNotPresent
-              image: "ghcr.io/jenkins-x/jx-boot:3.10.70"
+              image: "ghcr.io/jenkins-x/jx-boot:TESTVAL"
               env:
                 - name: JX_LOG_FORMAT
                   value: json

--- a/tests/test_data/custom-ingress-annotations-new/expected/batch/v1/CronJob/jx-gcjobs.yaml
+++ b/tests/test_data/custom-ingress-annotations-new/expected/batch/v1/CronJob/jx-gcjobs.yaml
@@ -30,7 +30,7 @@ spec:
                 - --namespace
                 - jx-git-operator
               imagePullPolicy: IfNotPresent
-              image: "ghcr.io/jenkins-x/jx-boot:3.10.70"
+              image: "ghcr.io/jenkins-x/jx-boot:TESTVAL"
               env:
                 - name: JX_LOG_FORMAT
                   value: json

--- a/tests/test_data/custom-ingress-annotations-new/expected/batch/v1/CronJob/jx-gcpods.yaml
+++ b/tests/test_data/custom-ingress-annotations-new/expected/batch/v1/CronJob/jx-gcpods.yaml
@@ -28,7 +28,7 @@ spec:
                 - gc
                 - pods
               imagePullPolicy: IfNotPresent
-              image: "ghcr.io/jenkins-x/jx-boot:3.10.70"
+              image: "ghcr.io/jenkins-x/jx-boot:TESTVAL"
               env:
                 - name: JX_LOG_FORMAT
                   value: json

--- a/tests/test_data/custom-ingress-annotations-new/values/jxRequirements.values.yaml
+++ b/tests/test_data/custom-ingress-annotations-new/values/jxRequirements.values.yaml
@@ -1,6 +1,11 @@
 versions:
   # TODO update with latest builders version
   builders: latest
+  # we set the versions of jx & updatebot to TESTVAL
+  # in order to ensure tests are deterministic
+  # (templated file content doesn't change just because new versions are released)
+  jx: TESTVAL
+  updatebot: TESTVAL
 
 # TODO we want to remove exposecontroller at some point
 exposer: Ingress

--- a/tests/test_data/custom-ingress-annotations/expected/batch/v1/CronJob/jx-gcactivities.yaml
+++ b/tests/test_data/custom-ingress-annotations/expected/batch/v1/CronJob/jx-gcactivities.yaml
@@ -28,7 +28,7 @@ spec:
                 - gc
                 - activities
               imagePullPolicy: IfNotPresent
-              image: "ghcr.io/jenkins-x/jx-boot:3.10.70"
+              image: "ghcr.io/jenkins-x/jx-boot:TESTVAL"
               env:
                 - name: JX_LOG_FORMAT
                   value: json

--- a/tests/test_data/custom-ingress-annotations/expected/batch/v1/CronJob/jx-gcjobs.yaml
+++ b/tests/test_data/custom-ingress-annotations/expected/batch/v1/CronJob/jx-gcjobs.yaml
@@ -30,7 +30,7 @@ spec:
                 - --namespace
                 - jx-git-operator
               imagePullPolicy: IfNotPresent
-              image: "ghcr.io/jenkins-x/jx-boot:3.10.70"
+              image: "ghcr.io/jenkins-x/jx-boot:TESTVAL"
               env:
                 - name: JX_LOG_FORMAT
                   value: json

--- a/tests/test_data/custom-ingress-annotations/expected/batch/v1/CronJob/jx-gcpods.yaml
+++ b/tests/test_data/custom-ingress-annotations/expected/batch/v1/CronJob/jx-gcpods.yaml
@@ -28,7 +28,7 @@ spec:
                 - gc
                 - pods
               imagePullPolicy: IfNotPresent
-              image: "ghcr.io/jenkins-x/jx-boot:3.10.70"
+              image: "ghcr.io/jenkins-x/jx-boot:TESTVAL"
               env:
                 - name: JX_LOG_FORMAT
                   value: json

--- a/tests/test_data/custom-ingress-annotations/values/jxRequirements.values.yaml
+++ b/tests/test_data/custom-ingress-annotations/values/jxRequirements.values.yaml
@@ -1,6 +1,11 @@
 versions:
   # TODO update with latest builders version
   builders: latest
+  # we set the versions of jx & updatebot to TESTVAL
+  # in order to ensure tests are deterministic
+  # (templated file content doesn't change just because new versions are released)
+  jx: TESTVAL
+  updatebot: TESTVAL
 
 # TODO we want to remove exposecontroller at some point
 exposer: Ingress

--- a/tests/test_data/custom-ingress-host/expected/batch/v1/CronJob/jx-gcactivities.yaml
+++ b/tests/test_data/custom-ingress-host/expected/batch/v1/CronJob/jx-gcactivities.yaml
@@ -28,7 +28,7 @@ spec:
                 - gc
                 - activities
               imagePullPolicy: IfNotPresent
-              image: "ghcr.io/jenkins-x/jx-boot:3.10.70"
+              image: "ghcr.io/jenkins-x/jx-boot:TESTVAL"
               env:
                 - name: JX_LOG_FORMAT
                   value: json

--- a/tests/test_data/custom-ingress-host/expected/batch/v1/CronJob/jx-gcjobs.yaml
+++ b/tests/test_data/custom-ingress-host/expected/batch/v1/CronJob/jx-gcjobs.yaml
@@ -30,7 +30,7 @@ spec:
                 - --namespace
                 - jx-git-operator
               imagePullPolicy: IfNotPresent
-              image: "ghcr.io/jenkins-x/jx-boot:3.10.70"
+              image: "ghcr.io/jenkins-x/jx-boot:TESTVAL"
               env:
                 - name: JX_LOG_FORMAT
                   value: json

--- a/tests/test_data/custom-ingress-host/expected/batch/v1/CronJob/jx-gcpods.yaml
+++ b/tests/test_data/custom-ingress-host/expected/batch/v1/CronJob/jx-gcpods.yaml
@@ -28,7 +28,7 @@ spec:
                 - gc
                 - pods
               imagePullPolicy: IfNotPresent
-              image: "ghcr.io/jenkins-x/jx-boot:3.10.70"
+              image: "ghcr.io/jenkins-x/jx-boot:TESTVAL"
               env:
                 - name: JX_LOG_FORMAT
                   value: json

--- a/tests/test_data/custom-ingress-host/values/jxRequirements.values.yaml
+++ b/tests/test_data/custom-ingress-host/values/jxRequirements.values.yaml
@@ -1,6 +1,11 @@
 versions:
   # TODO update with latest builders version
   builders: latest
+  # we set the versions of jx & updatebot to TESTVAL
+  # in order to ensure tests are deterministic
+  # (templated file content doesn't change just because new versions are released)
+  jx: TESTVAL
+  updatebot: TESTVAL
 
 # TODO we want to remove exposecontroller at some point
 exposer: Ingress

--- a/tests/test_data/custom-ingress-secret/expected/batch/v1/CronJob/jx-gcactivities.yaml
+++ b/tests/test_data/custom-ingress-secret/expected/batch/v1/CronJob/jx-gcactivities.yaml
@@ -28,7 +28,7 @@ spec:
                 - gc
                 - activities
               imagePullPolicy: IfNotPresent
-              image: "ghcr.io/jenkins-x/jx-boot:3.10.70"
+              image: "ghcr.io/jenkins-x/jx-boot:TESTVAL"
               env:
                 - name: JX_LOG_FORMAT
                   value: json

--- a/tests/test_data/custom-ingress-secret/expected/batch/v1/CronJob/jx-gcjobs.yaml
+++ b/tests/test_data/custom-ingress-secret/expected/batch/v1/CronJob/jx-gcjobs.yaml
@@ -30,7 +30,7 @@ spec:
                 - --namespace
                 - jx-git-operator
               imagePullPolicy: IfNotPresent
-              image: "ghcr.io/jenkins-x/jx-boot:3.10.70"
+              image: "ghcr.io/jenkins-x/jx-boot:TESTVAL"
               env:
                 - name: JX_LOG_FORMAT
                   value: json

--- a/tests/test_data/custom-ingress-secret/expected/batch/v1/CronJob/jx-gcpods.yaml
+++ b/tests/test_data/custom-ingress-secret/expected/batch/v1/CronJob/jx-gcpods.yaml
@@ -28,7 +28,7 @@ spec:
                 - gc
                 - pods
               imagePullPolicy: IfNotPresent
-              image: "ghcr.io/jenkins-x/jx-boot:3.10.70"
+              image: "ghcr.io/jenkins-x/jx-boot:TESTVAL"
               env:
                 - name: JX_LOG_FORMAT
                   value: json

--- a/tests/test_data/custom-ingress-secret/values/jxRequirements.values.yaml
+++ b/tests/test_data/custom-ingress-secret/values/jxRequirements.values.yaml
@@ -1,6 +1,11 @@
 versions:
   # TODO update with latest builders version
   builders: latest
+  # we set the versions of jx & updatebot to TESTVAL
+  # in order to ensure tests are deterministic
+  # (templated file content doesn't change just because new versions are released)
+  jx: TESTVAL
+  updatebot: TESTVAL
 
 # TODO we want to remove exposecontroller at some point
 exposer: Ingress

--- a/tests/test_data/default/expected/batch/v1/CronJob/jx-gcactivities.yaml
+++ b/tests/test_data/default/expected/batch/v1/CronJob/jx-gcactivities.yaml
@@ -28,7 +28,7 @@ spec:
                 - gc
                 - activities
               imagePullPolicy: IfNotPresent
-              image: "ghcr.io/jenkins-x/jx-boot:3.10.70"
+              image: "ghcr.io/jenkins-x/jx-boot:TESTVAL"
               env:
                 - name: JX_LOG_FORMAT
                   value: json

--- a/tests/test_data/default/expected/batch/v1/CronJob/jx-gcjobs.yaml
+++ b/tests/test_data/default/expected/batch/v1/CronJob/jx-gcjobs.yaml
@@ -30,7 +30,7 @@ spec:
                 - --namespace
                 - jx-git-operator
               imagePullPolicy: IfNotPresent
-              image: "ghcr.io/jenkins-x/jx-boot:3.10.70"
+              image: "ghcr.io/jenkins-x/jx-boot:TESTVAL"
               env:
                 - name: JX_LOG_FORMAT
                   value: json

--- a/tests/test_data/default/expected/batch/v1/CronJob/jx-gcpods.yaml
+++ b/tests/test_data/default/expected/batch/v1/CronJob/jx-gcpods.yaml
@@ -28,7 +28,7 @@ spec:
                 - gc
                 - pods
               imagePullPolicy: IfNotPresent
-              image: "ghcr.io/jenkins-x/jx-boot:3.10.70"
+              image: "ghcr.io/jenkins-x/jx-boot:TESTVAL"
               env:
                 - name: JX_LOG_FORMAT
                   value: json

--- a/tests/test_data/default/values/jxRequirements.values.yaml
+++ b/tests/test_data/default/values/jxRequirements.values.yaml
@@ -1,6 +1,11 @@
 versions:
   # TODO update with latest builders version
   builders: latest
+  # we set the versions of jx & updatebot to TESTVAL
+  # in order to ensure tests are deterministic
+  # (templated file content doesn't change just because new versions are released)
+  jx: TESTVAL
+  updatebot: TESTVAL
 
 # TODO we want to remove exposecontroller at some point
 exposer: Ingress

--- a/tests/test_data/gitlab/expected/batch/v1/CronJob/jx-gcactivities.yaml
+++ b/tests/test_data/gitlab/expected/batch/v1/CronJob/jx-gcactivities.yaml
@@ -28,7 +28,7 @@ spec:
                 - gc
                 - activities
               imagePullPolicy: IfNotPresent
-              image: "ghcr.io/jenkins-x/jx-boot:3.10.70"
+              image: "ghcr.io/jenkins-x/jx-boot:TESTVAL"
               env:
                 - name: JX_LOG_FORMAT
                   value: json

--- a/tests/test_data/gitlab/expected/batch/v1/CronJob/jx-gcjobs.yaml
+++ b/tests/test_data/gitlab/expected/batch/v1/CronJob/jx-gcjobs.yaml
@@ -30,7 +30,7 @@ spec:
                 - --namespace
                 - jx-git-operator
               imagePullPolicy: IfNotPresent
-              image: "ghcr.io/jenkins-x/jx-boot:3.10.70"
+              image: "ghcr.io/jenkins-x/jx-boot:TESTVAL"
               env:
                 - name: JX_LOG_FORMAT
                   value: json

--- a/tests/test_data/gitlab/expected/batch/v1/CronJob/jx-gcpods.yaml
+++ b/tests/test_data/gitlab/expected/batch/v1/CronJob/jx-gcpods.yaml
@@ -28,7 +28,7 @@ spec:
                 - gc
                 - pods
               imagePullPolicy: IfNotPresent
-              image: "ghcr.io/jenkins-x/jx-boot:3.10.70"
+              image: "ghcr.io/jenkins-x/jx-boot:TESTVAL"
               env:
                 - name: JX_LOG_FORMAT
                   value: json

--- a/tests/test_data/gitlab/values/jxRequirements.values.yaml
+++ b/tests/test_data/gitlab/values/jxRequirements.values.yaml
@@ -1,6 +1,11 @@
 versions:
   # TODO update with latest builders version
   builders: latest
+  # we set the versions of jx & updatebot to TESTVAL
+  # in order to ensure tests are deterministic
+  # (templated file content doesn't change just because new versions are released)
+  jx: TESTVAL
+  updatebot: TESTVAL
 
 # TODO we want to remove exposecontroller at some point
 exposer: Ingress

--- a/tests/test_data/gke-domain-bucketrepo/expected/batch/v1/CronJob/jx-gcactivities.yaml
+++ b/tests/test_data/gke-domain-bucketrepo/expected/batch/v1/CronJob/jx-gcactivities.yaml
@@ -28,7 +28,7 @@ spec:
                 - gc
                 - activities
               imagePullPolicy: IfNotPresent
-              image: "ghcr.io/jenkins-x/jx-boot:3.10.70"
+              image: "ghcr.io/jenkins-x/jx-boot:TESTVAL"
               env:
                 - name: JX_LOG_FORMAT
                   value: json

--- a/tests/test_data/gke-domain-bucketrepo/expected/batch/v1/CronJob/jx-gcjobs.yaml
+++ b/tests/test_data/gke-domain-bucketrepo/expected/batch/v1/CronJob/jx-gcjobs.yaml
@@ -30,7 +30,7 @@ spec:
                 - --namespace
                 - jx-git-operator
               imagePullPolicy: IfNotPresent
-              image: "ghcr.io/jenkins-x/jx-boot:3.10.70"
+              image: "ghcr.io/jenkins-x/jx-boot:TESTVAL"
               env:
                 - name: JX_LOG_FORMAT
                   value: json

--- a/tests/test_data/gke-domain-bucketrepo/expected/batch/v1/CronJob/jx-gcpods.yaml
+++ b/tests/test_data/gke-domain-bucketrepo/expected/batch/v1/CronJob/jx-gcpods.yaml
@@ -28,7 +28,7 @@ spec:
                 - gc
                 - pods
               imagePullPolicy: IfNotPresent
-              image: "ghcr.io/jenkins-x/jx-boot:3.10.70"
+              image: "ghcr.io/jenkins-x/jx-boot:TESTVAL"
               env:
                 - name: JX_LOG_FORMAT
                   value: json

--- a/tests/test_data/gke-domain-bucketrepo/values/jxRequirements.values.yaml
+++ b/tests/test_data/gke-domain-bucketrepo/values/jxRequirements.values.yaml
@@ -1,6 +1,11 @@
 versions:
   # TODO update with latest builders version
   builders: latest
+  # we set the versions of jx & updatebot to TESTVAL
+  # in order to ensure tests are deterministic
+  # (templated file content doesn't change just because new versions are released)
+  jx: TESTVAL
+  updatebot: TESTVAL
 
 # TODO we want to remove exposecontroller at some point
 exposer: Ingress

--- a/tests/test_data/gke-domain-no-repo/expected/batch/v1/CronJob/jx-gcactivities.yaml
+++ b/tests/test_data/gke-domain-no-repo/expected/batch/v1/CronJob/jx-gcactivities.yaml
@@ -28,7 +28,7 @@ spec:
                 - gc
                 - activities
               imagePullPolicy: IfNotPresent
-              image: "ghcr.io/jenkins-x/jx-boot:3.10.70"
+              image: "ghcr.io/jenkins-x/jx-boot:TESTVAL"
               env:
                 - name: JX_LOG_FORMAT
                   value: json

--- a/tests/test_data/gke-domain-no-repo/expected/batch/v1/CronJob/jx-gcjobs.yaml
+++ b/tests/test_data/gke-domain-no-repo/expected/batch/v1/CronJob/jx-gcjobs.yaml
@@ -30,7 +30,7 @@ spec:
                 - --namespace
                 - jx-git-operator
               imagePullPolicy: IfNotPresent
-              image: "ghcr.io/jenkins-x/jx-boot:3.10.70"
+              image: "ghcr.io/jenkins-x/jx-boot:TESTVAL"
               env:
                 - name: JX_LOG_FORMAT
                   value: json

--- a/tests/test_data/gke-domain-no-repo/expected/batch/v1/CronJob/jx-gcpods.yaml
+++ b/tests/test_data/gke-domain-no-repo/expected/batch/v1/CronJob/jx-gcpods.yaml
@@ -28,7 +28,7 @@ spec:
                 - gc
                 - pods
               imagePullPolicy: IfNotPresent
-              image: "ghcr.io/jenkins-x/jx-boot:3.10.70"
+              image: "ghcr.io/jenkins-x/jx-boot:TESTVAL"
               env:
                 - name: JX_LOG_FORMAT
                   value: json

--- a/tests/test_data/gke-domain-no-repo/values/jxRequirements.values.yaml
+++ b/tests/test_data/gke-domain-no-repo/values/jxRequirements.values.yaml
@@ -1,6 +1,11 @@
 versions:
   # TODO update with latest builders version
   builders: latest
+  # we set the versions of jx & updatebot to TESTVAL
+  # in order to ensure tests are deterministic
+  # (templated file content doesn't change just because new versions are released)
+  jx: TESTVAL
+  updatebot: TESTVAL
 
 # TODO we want to remove exposecontroller at some point
 exposer: Ingress

--- a/tests/test_data/gke-domain-none-repo/expected/batch/v1/CronJob/jx-gcactivities.yaml
+++ b/tests/test_data/gke-domain-none-repo/expected/batch/v1/CronJob/jx-gcactivities.yaml
@@ -28,7 +28,7 @@ spec:
                 - gc
                 - activities
               imagePullPolicy: IfNotPresent
-              image: "ghcr.io/jenkins-x/jx-boot:3.10.70"
+              image: "ghcr.io/jenkins-x/jx-boot:TESTVAL"
               env:
                 - name: JX_LOG_FORMAT
                   value: json

--- a/tests/test_data/gke-domain-none-repo/expected/batch/v1/CronJob/jx-gcjobs.yaml
+++ b/tests/test_data/gke-domain-none-repo/expected/batch/v1/CronJob/jx-gcjobs.yaml
@@ -30,7 +30,7 @@ spec:
                 - --namespace
                 - jx-git-operator
               imagePullPolicy: IfNotPresent
-              image: "ghcr.io/jenkins-x/jx-boot:3.10.70"
+              image: "ghcr.io/jenkins-x/jx-boot:TESTVAL"
               env:
                 - name: JX_LOG_FORMAT
                   value: json

--- a/tests/test_data/gke-domain-none-repo/expected/batch/v1/CronJob/jx-gcpods.yaml
+++ b/tests/test_data/gke-domain-none-repo/expected/batch/v1/CronJob/jx-gcpods.yaml
@@ -28,7 +28,7 @@ spec:
                 - gc
                 - pods
               imagePullPolicy: IfNotPresent
-              image: "ghcr.io/jenkins-x/jx-boot:3.10.70"
+              image: "ghcr.io/jenkins-x/jx-boot:TESTVAL"
               env:
                 - name: JX_LOG_FORMAT
                   value: json

--- a/tests/test_data/gke-domain-none-repo/values/jxRequirements.values.yaml
+++ b/tests/test_data/gke-domain-none-repo/values/jxRequirements.values.yaml
@@ -1,6 +1,11 @@
 versions:
   # TODO update with latest builders version
   builders: latest
+  # we set the versions of jx & updatebot to TESTVAL
+  # in order to ensure tests are deterministic
+  # (templated file content doesn't change just because new versions are released)
+  jx: TESTVAL
+  updatebot: TESTVAL
 
 # TODO we want to remove exposecontroller at some point
 exposer: Ingress

--- a/tests/test_data/gke-domain-v1beta1/expected/batch/v1/CronJob/jx-gcactivities.yaml
+++ b/tests/test_data/gke-domain-v1beta1/expected/batch/v1/CronJob/jx-gcactivities.yaml
@@ -28,7 +28,7 @@ spec:
                 - gc
                 - activities
               imagePullPolicy: IfNotPresent
-              image: "ghcr.io/jenkins-x/jx-boot:3.10.70"
+              image: "ghcr.io/jenkins-x/jx-boot:TESTVAL"
               env:
                 - name: JX_LOG_FORMAT
                   value: json

--- a/tests/test_data/gke-domain-v1beta1/expected/batch/v1/CronJob/jx-gcjobs.yaml
+++ b/tests/test_data/gke-domain-v1beta1/expected/batch/v1/CronJob/jx-gcjobs.yaml
@@ -30,7 +30,7 @@ spec:
                 - --namespace
                 - jx-git-operator
               imagePullPolicy: IfNotPresent
-              image: "ghcr.io/jenkins-x/jx-boot:3.10.70"
+              image: "ghcr.io/jenkins-x/jx-boot:TESTVAL"
               env:
                 - name: JX_LOG_FORMAT
                   value: json

--- a/tests/test_data/gke-domain-v1beta1/expected/batch/v1/CronJob/jx-gcpods.yaml
+++ b/tests/test_data/gke-domain-v1beta1/expected/batch/v1/CronJob/jx-gcpods.yaml
@@ -28,7 +28,7 @@ spec:
                 - gc
                 - pods
               imagePullPolicy: IfNotPresent
-              image: "ghcr.io/jenkins-x/jx-boot:3.10.70"
+              image: "ghcr.io/jenkins-x/jx-boot:TESTVAL"
               env:
                 - name: JX_LOG_FORMAT
                   value: json

--- a/tests/test_data/gke-domain-v1beta1/values/jxRequirements.values.yaml
+++ b/tests/test_data/gke-domain-v1beta1/values/jxRequirements.values.yaml
@@ -1,6 +1,11 @@
 versions:
   # TODO update with latest builders version
   builders: latest
+  # we set the versions of jx & updatebot to TESTVAL
+  # in order to ensure tests are deterministic
+  # (templated file content doesn't change just because new versions are released)
+  jx: TESTVAL
+  updatebot: TESTVAL
 
 # TODO we want to remove exposecontroller at some point
 exposer: Ingress

--- a/tests/test_data/gke-domain/expected/batch/v1/CronJob/jx-gcactivities.yaml
+++ b/tests/test_data/gke-domain/expected/batch/v1/CronJob/jx-gcactivities.yaml
@@ -28,7 +28,7 @@ spec:
                 - gc
                 - activities
               imagePullPolicy: IfNotPresent
-              image: "ghcr.io/jenkins-x/jx-boot:3.10.70"
+              image: "ghcr.io/jenkins-x/jx-boot:TESTVAL"
               env:
                 - name: JX_LOG_FORMAT
                   value: json

--- a/tests/test_data/gke-domain/expected/batch/v1/CronJob/jx-gcjobs.yaml
+++ b/tests/test_data/gke-domain/expected/batch/v1/CronJob/jx-gcjobs.yaml
@@ -30,7 +30,7 @@ spec:
                 - --namespace
                 - jx-git-operator
               imagePullPolicy: IfNotPresent
-              image: "ghcr.io/jenkins-x/jx-boot:3.10.70"
+              image: "ghcr.io/jenkins-x/jx-boot:TESTVAL"
               env:
                 - name: JX_LOG_FORMAT
                   value: json

--- a/tests/test_data/gke-domain/expected/batch/v1/CronJob/jx-gcpods.yaml
+++ b/tests/test_data/gke-domain/expected/batch/v1/CronJob/jx-gcpods.yaml
@@ -28,7 +28,7 @@ spec:
                 - gc
                 - pods
               imagePullPolicy: IfNotPresent
-              image: "ghcr.io/jenkins-x/jx-boot:3.10.70"
+              image: "ghcr.io/jenkins-x/jx-boot:TESTVAL"
               env:
                 - name: JX_LOG_FORMAT
                   value: json

--- a/tests/test_data/gke-domain/values/jxRequirements.values.yaml
+++ b/tests/test_data/gke-domain/values/jxRequirements.values.yaml
@@ -1,6 +1,11 @@
 versions:
   # TODO update with latest builders version
   builders: latest
+  # we set the versions of jx & updatebot to TESTVAL
+  # in order to ensure tests are deterministic
+  # (templated file content doesn't change just because new versions are released)
+  jx: TESTVAL
+  updatebot: TESTVAL
 
 # TODO we want to remove exposecontroller at some point
 exposer: Ingress

--- a/tests/test_data/gke/expected/batch/v1/CronJob/jx-gcactivities.yaml
+++ b/tests/test_data/gke/expected/batch/v1/CronJob/jx-gcactivities.yaml
@@ -28,7 +28,7 @@ spec:
                 - gc
                 - activities
               imagePullPolicy: IfNotPresent
-              image: "ghcr.io/jenkins-x/jx-boot:3.10.70"
+              image: "ghcr.io/jenkins-x/jx-boot:TESTVAL"
               env:
                 - name: JX_LOG_FORMAT
                   value: json

--- a/tests/test_data/gke/expected/batch/v1/CronJob/jx-gcjobs.yaml
+++ b/tests/test_data/gke/expected/batch/v1/CronJob/jx-gcjobs.yaml
@@ -30,7 +30,7 @@ spec:
                 - --namespace
                 - jx-git-operator
               imagePullPolicy: IfNotPresent
-              image: "ghcr.io/jenkins-x/jx-boot:3.10.70"
+              image: "ghcr.io/jenkins-x/jx-boot:TESTVAL"
               env:
                 - name: JX_LOG_FORMAT
                   value: json

--- a/tests/test_data/gke/expected/batch/v1/CronJob/jx-gcpods.yaml
+++ b/tests/test_data/gke/expected/batch/v1/CronJob/jx-gcpods.yaml
@@ -28,7 +28,7 @@ spec:
                 - gc
                 - pods
               imagePullPolicy: IfNotPresent
-              image: "ghcr.io/jenkins-x/jx-boot:3.10.70"
+              image: "ghcr.io/jenkins-x/jx-boot:TESTVAL"
               env:
                 - name: JX_LOG_FORMAT
                   value: json

--- a/tests/test_data/gke/values/jxRequirements.values.yaml
+++ b/tests/test_data/gke/values/jxRequirements.values.yaml
@@ -1,6 +1,11 @@
 versions:
   # TODO update with latest builders version
   builders: latest
+  # we set the versions of jx & updatebot to TESTVAL
+  # in order to ensure tests are deterministic
+  # (templated file content doesn't change just because new versions are released)
+  jx: TESTVAL
+  updatebot: TESTVAL
 
 # TODO we want to remove exposecontroller at some point
 exposer: Ingress

--- a/tests/test_data/image-pull-secrets/expected/batch/v1/CronJob/jx-gcactivities.yaml
+++ b/tests/test_data/image-pull-secrets/expected/batch/v1/CronJob/jx-gcactivities.yaml
@@ -28,7 +28,7 @@ spec:
                 - gc
                 - activities
               imagePullPolicy: IfNotPresent
-              image: "ghcr.io/jenkins-x/jx-boot:3.10.70"
+              image: "ghcr.io/jenkins-x/jx-boot:TESTVAL"
               env:
                 - name: JX_LOG_FORMAT
                   value: json

--- a/tests/test_data/image-pull-secrets/expected/batch/v1/CronJob/jx-gcjobs.yaml
+++ b/tests/test_data/image-pull-secrets/expected/batch/v1/CronJob/jx-gcjobs.yaml
@@ -30,7 +30,7 @@ spec:
                 - --namespace
                 - jx-git-operator
               imagePullPolicy: IfNotPresent
-              image: "ghcr.io/jenkins-x/jx-boot:3.10.70"
+              image: "ghcr.io/jenkins-x/jx-boot:TESTVAL"
               env:
                 - name: JX_LOG_FORMAT
                   value: json

--- a/tests/test_data/image-pull-secrets/expected/batch/v1/CronJob/jx-gcpods.yaml
+++ b/tests/test_data/image-pull-secrets/expected/batch/v1/CronJob/jx-gcpods.yaml
@@ -28,7 +28,7 @@ spec:
                 - gc
                 - pods
               imagePullPolicy: IfNotPresent
-              image: "ghcr.io/jenkins-x/jx-boot:3.10.70"
+              image: "ghcr.io/jenkins-x/jx-boot:TESTVAL"
               env:
                 - name: JX_LOG_FORMAT
                   value: json

--- a/tests/test_data/image-pull-secrets/values/jxRequirements.values.yaml
+++ b/tests/test_data/image-pull-secrets/values/jxRequirements.values.yaml
@@ -1,6 +1,11 @@
 versions:
   # TODO update with latest builders version
   builders: latest
+  # we set the versions of jx & updatebot to TESTVAL
+  # in order to ensure tests are deterministic
+  # (templated file content doesn't change just because new versions are released)
+  jx: TESTVAL
+  updatebot: TESTVAL
 
 # TODO we want to remove exposecontroller at some point
 exposer: Ingress

--- a/tests/test_data/istio/expected/batch/v1/CronJob/jx-gcactivities.yaml
+++ b/tests/test_data/istio/expected/batch/v1/CronJob/jx-gcactivities.yaml
@@ -28,7 +28,7 @@ spec:
                 - gc
                 - activities
               imagePullPolicy: IfNotPresent
-              image: "ghcr.io/jenkins-x/jx-boot:3.10.70"
+              image: "ghcr.io/jenkins-x/jx-boot:TESTVAL"
               env:
                 - name: JX_LOG_FORMAT
                   value: json

--- a/tests/test_data/istio/expected/batch/v1/CronJob/jx-gcjobs.yaml
+++ b/tests/test_data/istio/expected/batch/v1/CronJob/jx-gcjobs.yaml
@@ -30,7 +30,7 @@ spec:
                 - --namespace
                 - jx-git-operator
               imagePullPolicy: IfNotPresent
-              image: "ghcr.io/jenkins-x/jx-boot:3.10.70"
+              image: "ghcr.io/jenkins-x/jx-boot:TESTVAL"
               env:
                 - name: JX_LOG_FORMAT
                   value: json

--- a/tests/test_data/istio/expected/batch/v1/CronJob/jx-gcpods.yaml
+++ b/tests/test_data/istio/expected/batch/v1/CronJob/jx-gcpods.yaml
@@ -28,7 +28,7 @@ spec:
                 - gc
                 - pods
               imagePullPolicy: IfNotPresent
-              image: "ghcr.io/jenkins-x/jx-boot:3.10.70"
+              image: "ghcr.io/jenkins-x/jx-boot:TESTVAL"
               env:
                 - name: JX_LOG_FORMAT
                   value: json

--- a/tests/test_data/istio/values/jxRequirements.values.yaml
+++ b/tests/test_data/istio/values/jxRequirements.values.yaml
@@ -1,6 +1,11 @@
 versions:
   # TODO update with latest builders version
   builders: latest
+  # we set the versions of jx & updatebot to TESTVAL
+  # in order to ensure tests are deterministic
+  # (templated file content doesn't change just because new versions are released)
+  jx: TESTVAL
+  updatebot: TESTVAL
 
 # TODO we want to remove exposecontroller at some point
 exposer: Ingress

--- a/tests/test_data/lighthouse-jx/expected/batch/v1/CronJob/jx-gcactivities.yaml
+++ b/tests/test_data/lighthouse-jx/expected/batch/v1/CronJob/jx-gcactivities.yaml
@@ -28,7 +28,7 @@ spec:
                 - gc
                 - activities
               imagePullPolicy: IfNotPresent
-              image: "ghcr.io/jenkins-x/jx-boot:3.10.70"
+              image: "ghcr.io/jenkins-x/jx-boot:TESTVAL"
               env:
                 - name: JX_LOG_FORMAT
                   value: json

--- a/tests/test_data/lighthouse-jx/expected/batch/v1/CronJob/jx-gcjobs.yaml
+++ b/tests/test_data/lighthouse-jx/expected/batch/v1/CronJob/jx-gcjobs.yaml
@@ -30,7 +30,7 @@ spec:
                 - --namespace
                 - jx-git-operator
               imagePullPolicy: IfNotPresent
-              image: "ghcr.io/jenkins-x/jx-boot:3.10.70"
+              image: "ghcr.io/jenkins-x/jx-boot:TESTVAL"
               env:
                 - name: JX_LOG_FORMAT
                   value: json

--- a/tests/test_data/lighthouse-jx/expected/batch/v1/CronJob/jx-gcpods.yaml
+++ b/tests/test_data/lighthouse-jx/expected/batch/v1/CronJob/jx-gcpods.yaml
@@ -28,7 +28,7 @@ spec:
                 - gc
                 - pods
               imagePullPolicy: IfNotPresent
-              image: "ghcr.io/jenkins-x/jx-boot:3.10.70"
+              image: "ghcr.io/jenkins-x/jx-boot:TESTVAL"
               env:
                 - name: JX_LOG_FORMAT
                   value: json

--- a/tests/test_data/lighthouse-jx/values/jxRequirements.values.yaml
+++ b/tests/test_data/lighthouse-jx/values/jxRequirements.values.yaml
@@ -8,6 +8,11 @@ pipeline:
 versions:
   # TODO update with latest builders version
   builders: latest
+  # we set the versions of jx & updatebot to TESTVAL
+  # in order to ensure tests are deterministic
+  # (templated file content doesn't change just because new versions are released)
+  jx: TESTVAL
+  updatebot: TESTVAL
 
 # TODO we want to remove exposecontroller at some point
 exposer: Ingress

--- a/tests/test_data/lighthouse-tekton/expected/batch/v1/CronJob/jx-gcactivities.yaml
+++ b/tests/test_data/lighthouse-tekton/expected/batch/v1/CronJob/jx-gcactivities.yaml
@@ -28,7 +28,7 @@ spec:
                 - gc
                 - activities
               imagePullPolicy: IfNotPresent
-              image: "ghcr.io/jenkins-x/jx-boot:3.10.70"
+              image: "ghcr.io/jenkins-x/jx-boot:TESTVAL"
               env:
                 - name: JX_LOG_FORMAT
                   value: json

--- a/tests/test_data/lighthouse-tekton/expected/batch/v1/CronJob/jx-gcjobs.yaml
+++ b/tests/test_data/lighthouse-tekton/expected/batch/v1/CronJob/jx-gcjobs.yaml
@@ -30,7 +30,7 @@ spec:
                 - --namespace
                 - jx-git-operator
               imagePullPolicy: IfNotPresent
-              image: "ghcr.io/jenkins-x/jx-boot:3.10.70"
+              image: "ghcr.io/jenkins-x/jx-boot:TESTVAL"
               env:
                 - name: JX_LOG_FORMAT
                   value: json

--- a/tests/test_data/lighthouse-tekton/expected/batch/v1/CronJob/jx-gcpods.yaml
+++ b/tests/test_data/lighthouse-tekton/expected/batch/v1/CronJob/jx-gcpods.yaml
@@ -28,7 +28,7 @@ spec:
                 - gc
                 - pods
               imagePullPolicy: IfNotPresent
-              image: "ghcr.io/jenkins-x/jx-boot:3.10.70"
+              image: "ghcr.io/jenkins-x/jx-boot:TESTVAL"
               env:
                 - name: JX_LOG_FORMAT
                   value: json

--- a/tests/test_data/lighthouse-tekton/values/jxRequirements.values.yaml
+++ b/tests/test_data/lighthouse-tekton/values/jxRequirements.values.yaml
@@ -8,6 +8,11 @@ pipeline:
 versions:
   # TODO update with latest builders version
   builders: latest
+  # we set the versions of jx & updatebot to TESTVAL
+  # in order to ensure tests are deterministic
+  # (templated file content doesn't change just because new versions are released)
+  jx: TESTVAL
+  updatebot: TESTVAL
 
 # TODO we want to remove exposecontroller at some point
 exposer: Ingress

--- a/tests/test_data/no-envs/expected/batch/v1/CronJob/jx-gcactivities.yaml
+++ b/tests/test_data/no-envs/expected/batch/v1/CronJob/jx-gcactivities.yaml
@@ -28,7 +28,7 @@ spec:
                 - gc
                 - activities
               imagePullPolicy: IfNotPresent
-              image: "ghcr.io/jenkins-x/jx-boot:3.10.70"
+              image: "ghcr.io/jenkins-x/jx-boot:TESTVAL"
               env:
                 - name: JX_LOG_FORMAT
                   value: json

--- a/tests/test_data/no-envs/expected/batch/v1/CronJob/jx-gcjobs.yaml
+++ b/tests/test_data/no-envs/expected/batch/v1/CronJob/jx-gcjobs.yaml
@@ -30,7 +30,7 @@ spec:
                 - --namespace
                 - jx-git-operator
               imagePullPolicy: IfNotPresent
-              image: "ghcr.io/jenkins-x/jx-boot:3.10.70"
+              image: "ghcr.io/jenkins-x/jx-boot:TESTVAL"
               env:
                 - name: JX_LOG_FORMAT
                   value: json

--- a/tests/test_data/no-envs/expected/batch/v1/CronJob/jx-gcpods.yaml
+++ b/tests/test_data/no-envs/expected/batch/v1/CronJob/jx-gcpods.yaml
@@ -28,7 +28,7 @@ spec:
                 - gc
                 - pods
               imagePullPolicy: IfNotPresent
-              image: "ghcr.io/jenkins-x/jx-boot:3.10.70"
+              image: "ghcr.io/jenkins-x/jx-boot:TESTVAL"
               env:
                 - name: JX_LOG_FORMAT
                   value: json

--- a/tests/test_data/no-envs/values/jxRequirements.values.yaml
+++ b/tests/test_data/no-envs/values/jxRequirements.values.yaml
@@ -1,0 +1,8 @@
+versions:
+  # we only set this value to ensure that the CronJob definitions are deterministic
+  # (since the version number for the jx-boot pod changes regularly)
+  # we set the versions of jx & updatebot to TESTVAL
+  # in order to ensure tests are deterministic
+  # (templated file content doesn't change just because new versions are released)
+  jx: TESTVAL
+  updatebot: TESTVAL

--- a/tests/test_data/nodeport/expected/batch/v1/CronJob/jx-gcactivities.yaml
+++ b/tests/test_data/nodeport/expected/batch/v1/CronJob/jx-gcactivities.yaml
@@ -28,7 +28,7 @@ spec:
                 - gc
                 - activities
               imagePullPolicy: IfNotPresent
-              image: "ghcr.io/jenkins-x/jx-boot:3.10.70"
+              image: "ghcr.io/jenkins-x/jx-boot:TESTVAL"
               env:
                 - name: JX_LOG_FORMAT
                   value: json

--- a/tests/test_data/nodeport/expected/batch/v1/CronJob/jx-gcjobs.yaml
+++ b/tests/test_data/nodeport/expected/batch/v1/CronJob/jx-gcjobs.yaml
@@ -30,7 +30,7 @@ spec:
                 - --namespace
                 - jx-git-operator
               imagePullPolicy: IfNotPresent
-              image: "ghcr.io/jenkins-x/jx-boot:3.10.70"
+              image: "ghcr.io/jenkins-x/jx-boot:TESTVAL"
               env:
                 - name: JX_LOG_FORMAT
                   value: json

--- a/tests/test_data/nodeport/expected/batch/v1/CronJob/jx-gcpods.yaml
+++ b/tests/test_data/nodeport/expected/batch/v1/CronJob/jx-gcpods.yaml
@@ -28,7 +28,7 @@ spec:
                 - gc
                 - pods
               imagePullPolicy: IfNotPresent
-              image: "ghcr.io/jenkins-x/jx-boot:3.10.70"
+              image: "ghcr.io/jenkins-x/jx-boot:TESTVAL"
               env:
                 - name: JX_LOG_FORMAT
                   value: json

--- a/tests/test_data/nodeport/values/jxRequirements.values.yaml
+++ b/tests/test_data/nodeport/values/jxRequirements.values.yaml
@@ -1,6 +1,11 @@
 versions:
   # TODO update with latest builders version
   builders: latest
+  # we set the versions of jx & updatebot to TESTVAL
+  # in order to ensure tests are deterministic
+  # (templated file content doesn't change just because new versions are released)
+  jx: TESTVAL
+  updatebot: TESTVAL
 
 # TODO we want to remove exposecontroller at some point
 exposer: Ingress

--- a/tests/test_data/private-repo/expected/batch/v1/CronJob/jx-gcactivities.yaml
+++ b/tests/test_data/private-repo/expected/batch/v1/CronJob/jx-gcactivities.yaml
@@ -28,7 +28,7 @@ spec:
                 - gc
                 - activities
               imagePullPolicy: IfNotPresent
-              image: "ghcr.io/jenkins-x/jx-boot:3.10.70"
+              image: "ghcr.io/jenkins-x/jx-boot:TESTVAL"
               env:
                 - name: JX_LOG_FORMAT
                   value: json

--- a/tests/test_data/private-repo/expected/batch/v1/CronJob/jx-gcjobs.yaml
+++ b/tests/test_data/private-repo/expected/batch/v1/CronJob/jx-gcjobs.yaml
@@ -30,7 +30,7 @@ spec:
                 - --namespace
                 - jx-git-operator
               imagePullPolicy: IfNotPresent
-              image: "ghcr.io/jenkins-x/jx-boot:3.10.70"
+              image: "ghcr.io/jenkins-x/jx-boot:TESTVAL"
               env:
                 - name: JX_LOG_FORMAT
                   value: json

--- a/tests/test_data/private-repo/expected/batch/v1/CronJob/jx-gcpods.yaml
+++ b/tests/test_data/private-repo/expected/batch/v1/CronJob/jx-gcpods.yaml
@@ -28,7 +28,7 @@ spec:
                 - gc
                 - pods
               imagePullPolicy: IfNotPresent
-              image: "ghcr.io/jenkins-x/jx-boot:3.10.70"
+              image: "ghcr.io/jenkins-x/jx-boot:TESTVAL"
               env:
                 - name: JX_LOG_FORMAT
                   value: json

--- a/tests/test_data/private-repo/values/jxRequirements.values.yaml
+++ b/tests/test_data/private-repo/values/jxRequirements.values.yaml
@@ -1,6 +1,11 @@
 versions:
   # TODO update with latest builders version
   builders: latest
+  # we set the versions of jx & updatebot to TESTVAL
+  # in order to ensure tests are deterministic
+  # (templated file content doesn't change just because new versions are released)
+  jx: TESTVAL
+  updatebot: TESTVAL
 
 # TODO we want to remove exposecontroller at some point
 exposer: Ingress

--- a/tests/test_data/remote-env/expected/batch/v1/CronJob/jx-gcactivities.yaml
+++ b/tests/test_data/remote-env/expected/batch/v1/CronJob/jx-gcactivities.yaml
@@ -28,7 +28,7 @@ spec:
                 - gc
                 - activities
               imagePullPolicy: IfNotPresent
-              image: "ghcr.io/jenkins-x/jx-boot:3.10.70"
+              image: "ghcr.io/jenkins-x/jx-boot:TESTVAL"
               env:
                 - name: JX_LOG_FORMAT
                   value: json

--- a/tests/test_data/remote-env/expected/batch/v1/CronJob/jx-gcjobs.yaml
+++ b/tests/test_data/remote-env/expected/batch/v1/CronJob/jx-gcjobs.yaml
@@ -30,7 +30,7 @@ spec:
                 - --namespace
                 - jx-git-operator
               imagePullPolicy: IfNotPresent
-              image: "ghcr.io/jenkins-x/jx-boot:3.10.70"
+              image: "ghcr.io/jenkins-x/jx-boot:TESTVAL"
               env:
                 - name: JX_LOG_FORMAT
                   value: json

--- a/tests/test_data/remote-env/expected/batch/v1/CronJob/jx-gcpods.yaml
+++ b/tests/test_data/remote-env/expected/batch/v1/CronJob/jx-gcpods.yaml
@@ -28,7 +28,7 @@ spec:
                 - gc
                 - pods
               imagePullPolicy: IfNotPresent
-              image: "ghcr.io/jenkins-x/jx-boot:3.10.70"
+              image: "ghcr.io/jenkins-x/jx-boot:TESTVAL"
               env:
                 - name: JX_LOG_FORMAT
                   value: json

--- a/tests/test_data/remote-env/values/jxRequirements.values.yaml
+++ b/tests/test_data/remote-env/values/jxRequirements.values.yaml
@@ -1,6 +1,11 @@
 versions:
   # TODO update with latest builders version
   builders: latest
+  # we set the versions of jx & updatebot to TESTVAL
+  # in order to ensure tests are deterministic
+  # (templated file content doesn't change just because new versions are released)
+  jx: TESTVAL
+  updatebot: TESTVAL
 
 # TODO we want to remove exposecontroller at some point
 exposer: Ingress

--- a/tests/test_data/upgrade/expected/batch/v1/CronJob/jx-boot-upgrade.yaml
+++ b/tests/test_data/upgrade/expected/batch/v1/CronJob/jx-boot-upgrade.yaml
@@ -30,7 +30,7 @@ spec:
               - --to
               - jx
               name: copy-secret
-              image: "ghcr.io/jenkins-x/jx-boot:3.10.70"
+              image: "ghcr.io/jenkins-x/jx-boot:TESTVAL"
               imagePullPolicy: Always
               resources: {}
               terminationMessagePath: /dev/termination-log
@@ -49,7 +49,7 @@ spec:
             - secretRef:
                 name: jx-boot-job-env-vars
                 optional: true
-            image: "ghcr.io/jenkins-x/jx-updatebot:0.4.5"
+            image: "ghcr.io/jenkins-x/jx-updatebot:TESTVAL"
             imagePullPolicy: Always
             name: updatebot
             resources: {}

--- a/tests/test_data/upgrade/expected/batch/v1/CronJob/jx-gcactivities.yaml
+++ b/tests/test_data/upgrade/expected/batch/v1/CronJob/jx-gcactivities.yaml
@@ -28,7 +28,7 @@ spec:
                 - gc
                 - activities
               imagePullPolicy: IfNotPresent
-              image: "ghcr.io/jenkins-x/jx-boot:3.10.70"
+              image: "ghcr.io/jenkins-x/jx-boot:TESTVAL"
               env:
                 - name: JX_LOG_FORMAT
                   value: json

--- a/tests/test_data/upgrade/expected/batch/v1/CronJob/jx-gcjobs.yaml
+++ b/tests/test_data/upgrade/expected/batch/v1/CronJob/jx-gcjobs.yaml
@@ -30,7 +30,7 @@ spec:
                 - --namespace
                 - jx-git-operator
               imagePullPolicy: IfNotPresent
-              image: "ghcr.io/jenkins-x/jx-boot:3.10.70"
+              image: "ghcr.io/jenkins-x/jx-boot:TESTVAL"
               env:
                 - name: JX_LOG_FORMAT
                   value: json

--- a/tests/test_data/upgrade/expected/batch/v1/CronJob/jx-gcpods.yaml
+++ b/tests/test_data/upgrade/expected/batch/v1/CronJob/jx-gcpods.yaml
@@ -28,7 +28,7 @@ spec:
                 - gc
                 - pods
               imagePullPolicy: IfNotPresent
-              image: "ghcr.io/jenkins-x/jx-boot:3.10.70"
+              image: "ghcr.io/jenkins-x/jx-boot:TESTVAL"
               env:
                 - name: JX_LOG_FORMAT
                   value: json

--- a/tests/test_data/upgrade/values/jxRequirements.values.yaml
+++ b/tests/test_data/upgrade/values/jxRequirements.values.yaml
@@ -1,6 +1,11 @@
 versions:
   # TODO update with latest builders version
   builders: latest
+  # we set the versions of jx & updatebot to TESTVAL
+  # in order to ensure tests are deterministic
+  # (templated file content doesn't change just because new versions are released)
+  jx: TESTVAL
+  updatebot: TESTVAL
 
 # TODO we want to remove exposecontroller at some point
 exposer: Ingress


### PR DESCRIPTION
Added the `build-make-test` step from go-cli so that tests are run before the `build-helm-build` step in the pullrequest pipeline.

(I also added a fixed string to `.Values.versions.jx` in the tests so the compared values shouldn't drift)

Signed-off-by: Andy Nelson <andy.nelson@quant.network>