### PR TITLE
feat: Migrate from ingressclass annotation to spec

### DIFF
--- a/charts/jxboot-helmfile-resources/templates/700-bucketrepo-ing.yaml
+++ b/charts/jxboot-helmfile-resources/templates/700-bucketrepo-ing.yaml
@@ -6,6 +6,7 @@ metadata:
 {{- template "ingressAnnotations" (dict "Values" .Values "component" "bucketrepo") }}
   name: bucketrepo
 spec:
+  ingressClassName: {{ .Values.ingress.customIngressClass | default "nginx" }}
   rules:
   - http:
       paths:

--- a/charts/jxboot-helmfile-resources/templates/700-chartmuseum-ing.yaml
+++ b/charts/jxboot-helmfile-resources/templates/700-chartmuseum-ing.yaml
@@ -6,6 +6,7 @@ metadata:
 {{- template "ingressAnnotations" (dict "Values" .Values "component" "chartmuseum") }}
   name: chartmuseum
 spec:
+  ingressClassName: {{ .Values.ingress.customIngressClass | default "nginx" }}
   rules:
   - http:
       paths:

--- a/charts/jxboot-helmfile-resources/templates/700-docker-ing.yaml
+++ b/charts/jxboot-helmfile-resources/templates/700-docker-ing.yaml
@@ -6,6 +6,7 @@ metadata:
 {{- template "ingressAnnotations" (dict "Values" .Values "component" "docker-registry") }}
   name: docker-registry
 spec:
+  ingressClassName: {{ .Values.ingress.customIngressClass | default "nginx" }}
   rules:
   - http:
       paths:

--- a/charts/jxboot-helmfile-resources/templates/700-hook-ing.yaml
+++ b/charts/jxboot-helmfile-resources/templates/700-hook-ing.yaml
@@ -6,6 +6,7 @@ metadata:
 {{- template "ingressAnnotations" (dict "Values" .Values "component" "hook") }}
   name: hook
 spec:
+  ingressClassName: {{ .Values.ingress.customIngressClass | default "nginx" }}
   rules:
   - http:
       paths:

--- a/charts/jxboot-helmfile-resources/templates/700-nexus-ing.yaml
+++ b/charts/jxboot-helmfile-resources/templates/700-nexus-ing.yaml
@@ -6,6 +6,7 @@ metadata:
 {{- template "ingressAnnotations" (dict "Values" .Values "component" "nexus") }}
   name: nexus
 spec:
+  ingressClassName: {{ .Values.ingress.customIngressClass | default "nginx" }}
   rules:
   - http:
       paths:

--- a/charts/jxboot-helmfile-resources/templates/_helpers.tpl
+++ b/charts/jxboot-helmfile-resources/templates/_helpers.tpl
@@ -8,26 +8,6 @@
 
   {{- $_ := merge $annotations .Values.ingress.annotations .Values.jxRequirements.ingress.annotations  }}
 
-  {{- if not (hasKey $annotations "kubernetes.io/ingress.class") }}
-    {{- $customIngressClass := "" }}
-    {{- if $componentSpec.ingress.customIngressClass }}
-      {{- $customIngressClass := $componentSpec.ingress.customIngressClass }}
-      {{- $_ := set $annotations "kubernetes.io/ingress.class" $customIngressClass }}
-    {{- else if hasKey .Values.ingress "customIngressClass" }}
-      {{- if eq .component "docker-registry" }}
-        {{- if hasKey .Values.ingress.customIngressClass "dockerRegistry" }}
-          {{- $customIngressClass := index .Values.ingress.customIngressClass "dockerRegistry" }}
-          {{- $_ := set $annotations "kubernetes.io/ingress.class" $customIngressClass }}
-        {{- end }}
-      {{- else if hasKey .Values.ingress.customIngressClass .component }}
-        {{- $customIngressClass := index .Values.ingress.customIngressClass .component }}
-        {{- $_ := set $annotations "kubernetes.io/ingress.class" $customIngressClass }}
-      {{- end }}
-    {{- end }}
-    {{- if not (hasKey $annotations "kubernetes.io/ingress.class") }}
-      {{- $_ := set $annotations "kubernetes.io/ingress.class" ($customIngressClass | default "nginx")  }}
-    {{- end }}
-  {{- end }}
   {{- if and (hasKey .Values.jxRequirements.ingress "serviceType") (.Values.jxRequirements.ingress.serviceType) (eq .Values.jxRequirements.ingress.serviceType "NodePort") (not (hasKey $annotations "jenkins.io/host")) }}
     {{- $_ := set $annotations "jenkins.io/host" .Values.jxRequirements.ingress.domain }}
   {{- end }}


### PR DESCRIPTION
Hello,

While reinstalling jx3 on some of our clusters, we noticed Ingress Classes were missing from helm templates specs (they are currently only present as annotations). 
I think the annotation syntax is deprecated so here is a simple PR to add the Ingress Classes in the Ingress specs for all helmfiles.
Here is a bit of k8s documentation for this: https://kubernetes.io/blog/2020/04/02/improvements-to-the-ingress-api-in-kubernetes-1.18/#specifying-the-class-of-an-ingress