### PR TITLE
feat: add configurable image registry support

### DIFF
--- a/charts/jxboot-helmfile-resources/templates/jx-gcactivities-cronjob.yaml
+++ b/charts/jxboot-helmfile-resources/templates/jx-gcactivities-cronjob.yaml
@@ -38,7 +38,7 @@ spec:
               {{- end }}
             {{- end}}
               imagePullPolicy: IfNotPresent
-              image: "{{ .Values.image.parentRepository }}/jx-boot:{{ .Values.versions.jx }}"
+              image: "{{ .Values.jxBoot.image.repository }}:{{ .Values.versions.jx }}"
               env:
                 - name: JX_LOG_FORMAT
                   value: json

--- a/charts/jxboot-helmfile-resources/templates/jx-gcactivities-cronjob.yaml
+++ b/charts/jxboot-helmfile-resources/templates/jx-gcactivities-cronjob.yaml
@@ -38,7 +38,7 @@ spec:
               {{- end }}
             {{- end}}
               imagePullPolicy: IfNotPresent
-              image: "{{ .Values.jxBoot.image.repository }}:{{ .Values.versions.jx }}"
+              image: "{{ .Values.image.parentRepository }}/jx-boot:{{ .Values.versions.jx }}"
               env:
                 - name: JX_LOG_FORMAT
                   value: json

--- a/charts/jxboot-helmfile-resources/templates/jx-gcactivities-cronjob.yaml
+++ b/charts/jxboot-helmfile-resources/templates/jx-gcactivities-cronjob.yaml
@@ -38,7 +38,7 @@ spec:
               {{- end }}
             {{- end}}
               imagePullPolicy: IfNotPresent
-              image: "{{ .Values.image.registry }}/{{ .Values.image.jxBootRepository }}:{{ .Values.versions.jx }}"
+              image: "{{ .Values.jxBoot.image.repository }}:{{ .Values.versions.jx }}"
               env:
                 - name: JX_LOG_FORMAT
                   value: json

--- a/charts/jxboot-helmfile-resources/templates/jx-gcactivities-cronjob.yaml
+++ b/charts/jxboot-helmfile-resources/templates/jx-gcactivities-cronjob.yaml
@@ -38,7 +38,7 @@ spec:
               {{- end }}
             {{- end}}
               imagePullPolicy: IfNotPresent
-              image: "ghcr.io/jenkins-x/jx-boot:{{ .Values.versions.jx }}"
+              image: "{{ .Values.image.registry }}/{{ .Values.image.jxBootRepository }}:{{ .Values.versions.jx }}"
               env:
                 - name: JX_LOG_FORMAT
                   value: json

--- a/charts/jxboot-helmfile-resources/templates/jx-gcjobs-cronjob.yaml
+++ b/charts/jxboot-helmfile-resources/templates/jx-gcjobs-cronjob.yaml
@@ -38,7 +38,7 @@ spec:
               {{- end }}
             {{- end}}
               imagePullPolicy: IfNotPresent
-              image: "{{ .Values.image.parentRepository }}/jx-boot:{{ .Values.versions.jx }}"
+              image: "{{ .Values.jxBoot.image.repository }}:{{ .Values.versions.jx }}"
               env:
                 - name: JX_LOG_FORMAT
                   value: json

--- a/charts/jxboot-helmfile-resources/templates/jx-gcjobs-cronjob.yaml
+++ b/charts/jxboot-helmfile-resources/templates/jx-gcjobs-cronjob.yaml
@@ -38,7 +38,7 @@ spec:
               {{- end }}
             {{- end}}
               imagePullPolicy: IfNotPresent
-              image: "{{ .Values.jxBoot.image.repository }}:{{ .Values.versions.jx }}"
+              image: "{{ .Values.image.parentRepository }}/jx-boot:{{ .Values.versions.jx }}"
               env:
                 - name: JX_LOG_FORMAT
                   value: json

--- a/charts/jxboot-helmfile-resources/templates/jx-gcjobs-cronjob.yaml
+++ b/charts/jxboot-helmfile-resources/templates/jx-gcjobs-cronjob.yaml
@@ -38,7 +38,7 @@ spec:
               {{- end }}
             {{- end}}
               imagePullPolicy: IfNotPresent
-              image: "{{ .Values.image.registry }}/{{ .Values.image.jxBootRepository }}:{{ .Values.versions.jx }}"
+              image: "{{ .Values.jxBoot.image.repository }}:{{ .Values.versions.jx }}"
               env:
                 - name: JX_LOG_FORMAT
                   value: json

--- a/charts/jxboot-helmfile-resources/templates/jx-gcjobs-cronjob.yaml
+++ b/charts/jxboot-helmfile-resources/templates/jx-gcjobs-cronjob.yaml
@@ -38,7 +38,7 @@ spec:
               {{- end }}
             {{- end}}
               imagePullPolicy: IfNotPresent
-              image: "ghcr.io/jenkins-x/jx-boot:{{ .Values.versions.jx }}"
+              image: "{{ .Values.image.registry }}/{{ .Values.image.jxBootRepository }}:{{ .Values.versions.jx }}"
               env:
                 - name: JX_LOG_FORMAT
                   value: json

--- a/charts/jxboot-helmfile-resources/templates/jx-gcpods-cronjob.yaml
+++ b/charts/jxboot-helmfile-resources/templates/jx-gcpods-cronjob.yaml
@@ -38,7 +38,7 @@ spec:
               {{- end }}
             {{- end}}
               imagePullPolicy: IfNotPresent
-              image: "{{ .Values.image.parentRepository }}/jx-boot:{{ .Values.versions.jx }}"
+              image: "{{ .Values.jxBoot.image.repository }}:{{ .Values.versions.jx }}"
               env:
                 - name: JX_LOG_FORMAT
                   value: json

--- a/charts/jxboot-helmfile-resources/templates/jx-gcpods-cronjob.yaml
+++ b/charts/jxboot-helmfile-resources/templates/jx-gcpods-cronjob.yaml
@@ -38,7 +38,7 @@ spec:
               {{- end }}
             {{- end}}
               imagePullPolicy: IfNotPresent
-              image: "{{ .Values.jxBoot.image.repository }}:{{ .Values.versions.jx }}"
+              image: "{{ .Values.image.parentRepository }}/jx-boot:{{ .Values.versions.jx }}"
               env:
                 - name: JX_LOG_FORMAT
                   value: json

--- a/charts/jxboot-helmfile-resources/templates/jx-gcpods-cronjob.yaml
+++ b/charts/jxboot-helmfile-resources/templates/jx-gcpods-cronjob.yaml
@@ -38,7 +38,7 @@ spec:
               {{- end }}
             {{- end}}
               imagePullPolicy: IfNotPresent
-              image: "{{ .Values.image.registry }}/{{ .Values.image.jxBootRepository }}:{{ .Values.versions.jx }}"
+              image: "{{ .Values.jxBoot.image.repository }}:{{ .Values.versions.jx }}"
               env:
                 - name: JX_LOG_FORMAT
                   value: json

--- a/charts/jxboot-helmfile-resources/templates/jx-gcpods-cronjob.yaml
+++ b/charts/jxboot-helmfile-resources/templates/jx-gcpods-cronjob.yaml
@@ -38,7 +38,7 @@ spec:
               {{- end }}
             {{- end}}
               imagePullPolicy: IfNotPresent
-              image: "ghcr.io/jenkins-x/jx-boot:{{ .Values.versions.jx }}"
+              image: "{{ .Values.image.registry }}/{{ .Values.image.jxBootRepository }}:{{ .Values.versions.jx }}"
               env:
                 - name: JX_LOG_FORMAT
                   value: json

--- a/charts/jxboot-helmfile-resources/templates/upgrade-cj.yaml
+++ b/charts/jxboot-helmfile-resources/templates/upgrade-cj.yaml
@@ -33,7 +33,7 @@ spec:
               - --to
               - jx
               name: copy-secret
-              image: "ghcr.io/jenkins-x/jx-boot:{{ .Values.versions.jx }}"
+              image: "{{ .Values.image.registry }}/{{ .Values.image.jxBootRepository }}:{{ .Values.versions.jx }}"
               imagePullPolicy: Always
               resources: {}
               terminationMessagePath: /dev/termination-log
@@ -57,7 +57,7 @@ spec:
             - secretRef:
                 name: jx-boot-job-env-vars
                 optional: true
-            image: "ghcr.io/jenkins-x/jx-updatebot:{{ .Values.versions.updatebot }}"
+            image: "{{ .Values.image.registry }}/{{ .Values.image.updatebotRepository }}:{{ .Values.versions.updatebot }}"
             imagePullPolicy: Always
             name: updatebot
             resources: {}

--- a/charts/jxboot-helmfile-resources/templates/upgrade-cj.yaml
+++ b/charts/jxboot-helmfile-resources/templates/upgrade-cj.yaml
@@ -33,7 +33,7 @@ spec:
               - --to
               - jx
               name: copy-secret
-              image: "{{ .Values.image.parentRepository }}/jx-boot:{{ .Values.versions.jx }}"
+              image: "{{ .Values.jxBoot.image.repository }}:{{ .Values.versions.jx }}"
               imagePullPolicy: Always
               resources: {}
               terminationMessagePath: /dev/termination-log
@@ -57,7 +57,7 @@ spec:
             - secretRef:
                 name: jx-boot-job-env-vars
                 optional: true
-            image: "{{ .Values.image.parentRepository }}/jx-updatebot:{{ .Values.versions.updatebot }}"
+            image: "{{ .Values.updatebot.image.repository }}:{{ .Values.versions.updatebot }}"
             imagePullPolicy: Always
             name: updatebot
             resources: {}

--- a/charts/jxboot-helmfile-resources/templates/upgrade-cj.yaml
+++ b/charts/jxboot-helmfile-resources/templates/upgrade-cj.yaml
@@ -33,7 +33,7 @@ spec:
               - --to
               - jx
               name: copy-secret
-              image: "{{ .Values.image.registry }}/{{ .Values.image.jxBootRepository }}:{{ .Values.versions.jx }}"
+              image: "{{ .Values.jxBoot.image.repository }}:{{ .Values.versions.jx }}"
               imagePullPolicy: Always
               resources: {}
               terminationMessagePath: /dev/termination-log
@@ -57,7 +57,7 @@ spec:
             - secretRef:
                 name: jx-boot-job-env-vars
                 optional: true
-            image: "{{ .Values.image.registry }}/{{ .Values.image.updatebotRepository }}:{{ .Values.versions.updatebot }}"
+            image: "{{ .Values.updatebot.image.repository }}:{{ .Values.versions.updatebot }}"
             imagePullPolicy: Always
             name: updatebot
             resources: {}

--- a/charts/jxboot-helmfile-resources/templates/upgrade-cj.yaml
+++ b/charts/jxboot-helmfile-resources/templates/upgrade-cj.yaml
@@ -33,7 +33,7 @@ spec:
               - --to
               - jx
               name: copy-secret
-              image: "{{ .Values.jxBoot.image.repository }}:{{ .Values.versions.jx }}"
+              image: "{{ .Values.image.parentRepository }}/jx-boot:{{ .Values.versions.jx }}"
               imagePullPolicy: Always
               resources: {}
               terminationMessagePath: /dev/termination-log
@@ -57,7 +57,7 @@ spec:
             - secretRef:
                 name: jx-boot-job-env-vars
                 optional: true
-            image: "{{ .Values.updatebot.image.repository }}:{{ .Values.versions.updatebot }}"
+            image: "{{ .Values.image.parentRepository }}/jx-updatebot:{{ .Values.versions.updatebot }}"
             imagePullPolicy: Always
             name: updatebot
             resources: {}

--- a/charts/jxboot-helmfile-resources/values.yaml
+++ b/charts/jxboot-helmfile-resources/values.yaml
@@ -161,15 +161,19 @@ versions:
   # updatebot is the version of the jx-updatebot image
   updatebot: 0.8.10
 
+# Image configuration
+image:
+  parentRepository: ghcr.io/jenkins-x
+
 # JX Boot image configuration
 jxBoot:
   image:
-    repository: ghcr.io/jenkins-x/jx-boot
+    repository: "{{ .Values.image.parentRepository }}/jx-boot"
 
 # Updatebot image configuration
 updatebot:
   image:
-    repository: ghcr.io/jenkins-x/jx-updatebot
+    repository: "{{ .Values.image.parentRepository }}/jx-updatebot"
 
 # standard YAML files for jx boot:
 secrets:

--- a/charts/jxboot-helmfile-resources/values.yaml
+++ b/charts/jxboot-helmfile-resources/values.yaml
@@ -161,9 +161,15 @@ versions:
   # updatebot is the version of the jx-updatebot image
   updatebot: 0.8.10
 
-# Image configuration
-image:
-  parentRepository: ghcr.io/jenkins-x
+# JX Boot image configuration
+jxBoot:
+  image:
+    repository: ghcr.io/jenkins-x/jx-boot
+
+# Updatebot image configuration
+updatebot:
+  image:
+    repository: ghcr.io/jenkins-x/jx-updatebot
 
 # standard YAML files for jx boot:
 secrets:

--- a/charts/jxboot-helmfile-resources/values.yaml
+++ b/charts/jxboot-helmfile-resources/values.yaml
@@ -161,11 +161,15 @@ versions:
   # updatebot is the version of the jx-updatebot image
   updatebot: 0.8.10
 
-# Image registry configuration
-image:
-  registry: ghcr.io
-  jxBootRepository: jenkins-x/jx-boot
-  updatebotRepository: jenkins-x/jx-updatebot
+# JX Boot image configuration
+jxBoot:
+  image:
+    repository: ghcr.io/jenkins-x/jx-boot
+
+# Updatebot image configuration
+updatebot:
+  image:
+    repository: ghcr.io/jenkins-x/jx-updatebot
 
 # standard YAML files for jx boot:
 secrets:

--- a/charts/jxboot-helmfile-resources/values.yaml
+++ b/charts/jxboot-helmfile-resources/values.yaml
@@ -161,19 +161,15 @@ versions:
   # updatebot is the version of the jx-updatebot image
   updatebot: 0.8.10
 
-# Image configuration
-image:
-  parentRepository: ghcr.io/jenkins-x
-
 # JX Boot image configuration
 jxBoot:
   image:
-    repository: "{{ .Values.image.parentRepository }}/jx-boot"
+    repository: ghcr.io/jenkins-x/jx-boot
 
 # Updatebot image configuration
 updatebot:
   image:
-    repository: "{{ .Values.image.parentRepository }}/jx-updatebot"
+    repository: ghcr.io/jenkins-x/jx-updatebot
 
 # standard YAML files for jx boot:
 secrets:

--- a/charts/jxboot-helmfile-resources/values.yaml
+++ b/charts/jxboot-helmfile-resources/values.yaml
@@ -161,15 +161,9 @@ versions:
   # updatebot is the version of the jx-updatebot image
   updatebot: 0.8.10
 
-# JX Boot image configuration
-jxBoot:
-  image:
-    repository: ghcr.io/jenkins-x/jx-boot
-
-# Updatebot image configuration
-updatebot:
-  image:
-    repository: ghcr.io/jenkins-x/jx-updatebot
+# Image configuration
+image:
+  parentRepository: ghcr.io/jenkins-x
 
 # standard YAML files for jx boot:
 secrets:

--- a/charts/jxboot-helmfile-resources/values.yaml
+++ b/charts/jxboot-helmfile-resources/values.yaml
@@ -161,6 +161,12 @@ versions:
   # updatebot is the version of the jx-updatebot image
   updatebot: 0.8.10
 
+# Image registry configuration
+image:
+  registry: ghcr.io
+  jxBootRepository: jenkins-x/jx-boot
+  updatebotRepository: jenkins-x/jx-updatebot
+
 # standard YAML files for jx boot:
 secrets:
   adminUser:


### PR DESCRIPTION
- Add image.registry configuration in values.yaml
- Add image.jxBootRepository and image.updatebotRepository settings
- Update all CronJob templates to use configurable registry
- Maintains backward compatibility with default ghcr.io registry

This allows users to specify custom container registries instead of being limited to hardcoded ghcr.io registry.